### PR TITLE
Add two-way translation tests for cl_khr_subgroup_extensions.

### DIFF
--- a/test/transcoding/sub_group_ballot.ll
+++ b/test/transcoding/sub_group_ballot.ll
@@ -1,0 +1,1192 @@
+;; #pragma OPENCL EXTENSION cl_khr_subgroup_ballot : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+;; 
+;; kernel void testNonUniformBroadcastChars()
+;; {
+;;     char16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testNonUniformBroadcastUChars()
+;; {
+;;     uchar16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testNonUniformBroadcastShorts()
+;; {
+;;     short16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testNonUniformBroadcastUShorts()
+;; {
+;;     ushort16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testNonUniformBroadcastInts()
+;; {
+;;     int16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testNonUniformBroadcastUInts()
+;; {
+;;     uint16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testNonUniformBroadcastLongs()
+;; {
+;;     long16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testNonUniformBroadcastULongs()
+;; {
+;;     ulong16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testNonUniformBroadcastFloats()
+;; {
+;;     float16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testNonUniformBroadcastHalfs()
+;; {
+;;     half16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testNonUniformBroadcastDoubles()
+;; {
+;;     double16 v = 0;
+;;     v.s0 = sub_group_non_uniform_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_non_uniform_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_non_uniform_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_non_uniform_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_non_uniform_broadcast(v.s01234567, 0);
+;;     v = sub_group_non_uniform_broadcast(v, 0);
+;;     v.s0 = sub_group_broadcast_first(v.s0);
+;; }
+;; 
+;; kernel void testBallotOperations(global uint* dst)
+;; {
+;;     uint4 v = sub_group_ballot(0);
+;;     dst[0] = sub_group_inverse_ballot(v);
+;;     dst[1] = sub_group_ballot_bit_extract(v, 0);
+;;     dst[2] = sub_group_ballot_bit_count(v);
+;;     dst[3] = sub_group_ballot_inclusive_scan(v);
+;;     dst[4] = sub_group_ballot_exclusive_scan(v);
+;;     dst[5] = sub_group_ballot_find_lsb(v);
+;;     dst[6] = sub_group_ballot_find_msb(v);
+;; }
+;; 
+;; kernel void testSubgroupMasks(global uint4* dst)
+;; {
+;;     dst[0] = get_sub_group_eq_mask();
+;;     dst[1] = get_sub_group_ge_mask();
+;;     dst[2] = get_sub_group_gt_mask();
+;;     dst[3] = get_sub_group_le_mask();
+;;     dst[4] = get_sub_group_lt_mask();
+;; }
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; Change DISABLED to RUN once SPIRV->LLVM translation is implemented
+; DISABLED: llvm-spirv -r %t.spv -o %t.rev.bc
+; DISABLED: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; ModuleID = 'subgroup_ballot.cl'
+source_filename = "subgroup_ballot.cl"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+; CHECK-SPIRV-DAG: Decorate [[eqMask:[0-9]+]] BuiltIn 4416
+; CHECK-SPIRV-DAG: Decorate [[geMask:[0-9]+]] BuiltIn 4417
+; CHECK-SPIRV-DAG: Decorate [[gtMask:[0-9]+]] BuiltIn 4418
+; CHECK-SPIRV-DAG: Decorate [[leMask:[0-9]+]] BuiltIn 4419
+; CHECK-SPIRV-DAG: Decorate [[ltMask:[0-9]+]] BuiltIn 4420
+
+; CHECK-SPIRV-DAG: TypeBool  [[bool:[0-9]+]]
+; CHECK-SPIRV-DAG: TypeInt   [[char:[0-9]+]]   8  0
+; CHECK-SPIRV-DAG: TypeInt   [[short:[0-9]+]]  16 0
+; CHECK-SPIRV-DAG: TypeInt   [[int:[0-9]+]]    32 0
+; CHECK-SPIRV-DAG: TypeInt   [[long:[0-9]+]]   64 0
+; CHECK-SPIRV-DAG: TypeFloat [[half:[0-9]+]]   16
+; CHECK-SPIRV-DAG: TypeFloat [[float:[0-9]+]]  32
+; CHECK-SPIRV-DAG: TypeFloat [[double:[0-9]+]] 64
+
+; CHECK-SPIRV-DAG: TypeVector [[char2:[0-9]+]]  [[char]] 2
+; CHECK-SPIRV-DAG: TypeVector [[char3:[0-9]+]]  [[char]] 3
+; CHECK-SPIRV-DAG: TypeVector [[char4:[0-9]+]]  [[char]] 4
+; CHECK-SPIRV-DAG: TypeVector [[char8:[0-9]+]]  [[char]] 8
+; CHECK-SPIRV-DAG: TypeVector [[char16:[0-9]+]] [[char]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[short2:[0-9]+]]  [[short]] 2
+; CHECK-SPIRV-DAG: TypeVector [[short3:[0-9]+]]  [[short]] 3
+; CHECK-SPIRV-DAG: TypeVector [[short4:[0-9]+]]  [[short]] 4
+; CHECK-SPIRV-DAG: TypeVector [[short8:[0-9]+]]  [[short]] 8
+; CHECK-SPIRV-DAG: TypeVector [[short16:[0-9]+]] [[short]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[int2:[0-9]+]]  [[int]] 2
+; CHECK-SPIRV-DAG: TypeVector [[int3:[0-9]+]]  [[int]] 3
+; CHECK-SPIRV-DAG: TypeVector [[int4:[0-9]+]]  [[int]] 4
+; CHECK-SPIRV-DAG: TypeVector [[int8:[0-9]+]]  [[int]] 8
+; CHECK-SPIRV-DAG: TypeVector [[int16:[0-9]+]] [[int]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[long2:[0-9]+]]  [[long]] 2
+; CHECK-SPIRV-DAG: TypeVector [[long3:[0-9]+]]  [[long]] 3
+; CHECK-SPIRV-DAG: TypeVector [[long4:[0-9]+]]  [[long]] 4
+; CHECK-SPIRV-DAG: TypeVector [[long8:[0-9]+]]  [[long]] 8
+; CHECK-SPIRV-DAG: TypeVector [[long16:[0-9]+]] [[long]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[float2:[0-9]+]]  [[float]] 2
+; CHECK-SPIRV-DAG: TypeVector [[float3:[0-9]+]]  [[float]] 3
+; CHECK-SPIRV-DAG: TypeVector [[float4:[0-9]+]]  [[float]] 4
+; CHECK-SPIRV-DAG: TypeVector [[float8:[0-9]+]]  [[float]] 8
+; CHECK-SPIRV-DAG: TypeVector [[float16:[0-9]+]] [[float]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[half2:[0-9]+]]  [[half]] 2
+; CHECK-SPIRV-DAG: TypeVector [[half3:[0-9]+]]  [[half]] 3
+; CHECK-SPIRV-DAG: TypeVector [[half4:[0-9]+]]  [[half]] 4
+; CHECK-SPIRV-DAG: TypeVector [[half8:[0-9]+]]  [[half]] 8
+; CHECK-SPIRV-DAG: TypeVector [[half16:[0-9]+]] [[half]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[double2:[0-9]+]]  [[double]] 2
+; CHECK-SPIRV-DAG: TypeVector [[double3:[0-9]+]]  [[double]] 3
+; CHECK-SPIRV-DAG: TypeVector [[double4:[0-9]+]]  [[double]] 4
+; CHECK-SPIRV-DAG: TypeVector [[double8:[0-9]+]]  [[double]] 8
+; CHECK-SPIRV-DAG: TypeVector [[double16:[0-9]+]] [[double]] 16
+
+; CHECK-SPIRV-DAG: ConstantFalse [[bool]] [[false:[0-9]+]]
+; CHECK-SPIRV-DAG: Constant [[int]]    [[ScopeSubgroup:[0-9]+]] 3
+; CHECK-SPIRV-DAG: Constant [[char]]   [[char_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[short]]  [[short_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[int]]    [[int_0:[0-9]+]]         0
+; CHECK-SPIRV-DAG: Constant [[long]]   [[long_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[half]]   [[half_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[float]]  [[float_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[double]] [[double_0:[0-9]+]]      0
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char2]] [[char2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char2]] {{[0-9]+}} [[ScopeSubgroup]] [[char2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char3]] [[char3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char3]] {{[0-9]+}} [[ScopeSubgroup]] [[char3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char4]] [[char4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char4]] {{[0-9]+}} [[ScopeSubgroup]] [[char4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char8]] [[char8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char8]] {{[0-9]+}} [[ScopeSubgroup]] [[char8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[char16]] [[char16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char16]] {{[0-9]+}} [[ScopeSubgroup]] [[char16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[char]] [[char_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastChars
+; CHECK-LLVM: call spir_func i8 @_Z31sub_group_non_uniform_broadcasthj(i8 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i8> @_Z31sub_group_non_uniform_broadcastDv2_hj(<2 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i8> @_Z31sub_group_non_uniform_broadcastDv3_hj(<3 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i8> @_Z31sub_group_non_uniform_broadcastDv4_hj(<4 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i8> @_Z31sub_group_non_uniform_broadcastDv8_hj(<8 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i8> @_Z31sub_group_non_uniform_broadcastDv16_hj(<16 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func i8 @_Z25sub_group_broadcast_firsth(i8 {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastChars() local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func signext i8 @_Z31sub_group_non_uniform_broadcastcj(i8 signext 0, i32 0) #7
+  %2 = insertelement <16 x i8> <i8 undef, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0>, i8 %1, i64 0
+  %3 = shufflevector <16 x i8> %2, <16 x i8> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i8> @_Z31sub_group_non_uniform_broadcastDv2_cj(<2 x i8> %3, i32 0) #7
+  %5 = shufflevector <2 x i8> %4, <2 x i8> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i8> %5, <16 x i8> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i8> %6, <16 x i8> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i8> @_Z31sub_group_non_uniform_broadcastDv3_cj(<3 x i8> %7, i32 0) #7
+  %9 = shufflevector <3 x i8> %8, <3 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i8> %9, <16 x i8> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i8> %10, <16 x i8> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i8> @_Z31sub_group_non_uniform_broadcastDv4_cj(<4 x i8> %11, i32 0) #7
+  %13 = shufflevector <4 x i8> %12, <4 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i8> %13, <16 x i8> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i8> %14, <16 x i8> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i8> @_Z31sub_group_non_uniform_broadcastDv8_cj(<8 x i8> %15, i32 0) #7
+  %17 = shufflevector <8 x i8> %16, <8 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i8> %17, <16 x i8> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i8> @_Z31sub_group_non_uniform_broadcastDv16_cj(<16 x i8> %18, i32 0) #7
+  %20 = extractelement <16 x i8> %19, i64 0
+  %21 = tail call spir_func signext i8 @_Z25sub_group_broadcast_firstc(i8 signext %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z31sub_group_non_uniform_broadcastcj(i8 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i8> @_Z31sub_group_non_uniform_broadcastDv2_cj(<2 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i8> @_Z31sub_group_non_uniform_broadcastDv3_cj(<3 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i8> @_Z31sub_group_non_uniform_broadcastDv4_cj(<4 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i8> @_Z31sub_group_non_uniform_broadcastDv8_cj(<8 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i8> @_Z31sub_group_non_uniform_broadcastDv16_cj(<16 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z25sub_group_broadcast_firstc(i8 signext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char2]] [[char2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char2]] {{[0-9]+}} [[ScopeSubgroup]] [[char2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char3]] [[char3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char3]] {{[0-9]+}} [[ScopeSubgroup]] [[char3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char4]] [[char4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char4]] {{[0-9]+}} [[ScopeSubgroup]] [[char4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char8]] [[char8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char8]] {{[0-9]+}} [[ScopeSubgroup]] [[char8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[char16]] [[char16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[char16]] {{[0-9]+}} [[ScopeSubgroup]] [[char16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[char]] [[char_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastUChars
+; CHECK-LLVM: call spir_func i8 @_Z31sub_group_non_uniform_broadcasthj(i8 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i8> @_Z31sub_group_non_uniform_broadcastDv2_hj(<2 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i8> @_Z31sub_group_non_uniform_broadcastDv3_hj(<3 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i8> @_Z31sub_group_non_uniform_broadcastDv4_hj(<4 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i8> @_Z31sub_group_non_uniform_broadcastDv8_hj(<8 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i8> @_Z31sub_group_non_uniform_broadcastDv16_hj(<16 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func i8 @_Z25sub_group_broadcast_firsth(i8 {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastUChars() local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func zeroext i8 @_Z31sub_group_non_uniform_broadcasthj(i8 zeroext 0, i32 0) #7
+  %2 = insertelement <16 x i8> <i8 undef, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0>, i8 %1, i64 0
+  %3 = shufflevector <16 x i8> %2, <16 x i8> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i8> @_Z31sub_group_non_uniform_broadcastDv2_hj(<2 x i8> %3, i32 0) #7
+  %5 = shufflevector <2 x i8> %4, <2 x i8> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i8> %5, <16 x i8> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i8> %6, <16 x i8> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i8> @_Z31sub_group_non_uniform_broadcastDv3_hj(<3 x i8> %7, i32 0) #7
+  %9 = shufflevector <3 x i8> %8, <3 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i8> %9, <16 x i8> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i8> %10, <16 x i8> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i8> @_Z31sub_group_non_uniform_broadcastDv4_hj(<4 x i8> %11, i32 0) #7
+  %13 = shufflevector <4 x i8> %12, <4 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i8> %13, <16 x i8> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i8> %14, <16 x i8> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i8> @_Z31sub_group_non_uniform_broadcastDv8_hj(<8 x i8> %15, i32 0) #7
+  %17 = shufflevector <8 x i8> %16, <8 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i8> %17, <16 x i8> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i8> @_Z31sub_group_non_uniform_broadcastDv16_hj(<16 x i8> %18, i32 0) #7
+  %20 = extractelement <16 x i8> %19, i64 0
+  %21 = tail call spir_func zeroext i8 @_Z25sub_group_broadcast_firsth(i8 zeroext %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z31sub_group_non_uniform_broadcasthj(i8 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i8> @_Z31sub_group_non_uniform_broadcastDv2_hj(<2 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i8> @_Z31sub_group_non_uniform_broadcastDv3_hj(<3 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i8> @_Z31sub_group_non_uniform_broadcastDv4_hj(<4 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i8> @_Z31sub_group_non_uniform_broadcastDv8_hj(<8 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i8> @_Z31sub_group_non_uniform_broadcastDv16_hj(<16 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z25sub_group_broadcast_firsth(i8 zeroext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short2]] [[short2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short2]] {{[0-9]+}} [[ScopeSubgroup]] [[short2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short3]] [[short3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short3]] {{[0-9]+}} [[ScopeSubgroup]] [[short3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short4]] [[short4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short4]] {{[0-9]+}} [[ScopeSubgroup]] [[short4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short8]] [[short8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short8]] {{[0-9]+}} [[ScopeSubgroup]] [[short8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[short16]] [[short16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short16]] {{[0-9]+}} [[ScopeSubgroup]] [[short16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[short]] [[short_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastShorts
+; CHECK-LLVM: call spir_func i16 @_Z31sub_group_non_uniform_broadcasttj(i16 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i16> @_Z31sub_group_non_uniform_broadcastDv2_tj(<2 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i16> @_Z31sub_group_non_uniform_broadcastDv3_tj(<3 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i16> @_Z31sub_group_non_uniform_broadcastDv4_tj(<4 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i16> @_Z31sub_group_non_uniform_broadcastDv8_tj(<8 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i16> @_Z31sub_group_non_uniform_broadcastDv16_tj(<16 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func i16 @_Z25sub_group_broadcast_firstt(i16 {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastShorts() local_unnamed_addr #2 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func signext i16 @_Z31sub_group_non_uniform_broadcastsj(i16 signext 0, i32 0) #7
+  %2 = insertelement <16 x i16> <i16 undef, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0>, i16 %1, i64 0
+  %3 = shufflevector <16 x i16> %2, <16 x i16> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i16> @_Z31sub_group_non_uniform_broadcastDv2_sj(<2 x i16> %3, i32 0) #7
+  %5 = shufflevector <2 x i16> %4, <2 x i16> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i16> %5, <16 x i16> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i16> %6, <16 x i16> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i16> @_Z31sub_group_non_uniform_broadcastDv3_sj(<3 x i16> %7, i32 0) #7
+  %9 = shufflevector <3 x i16> %8, <3 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i16> %9, <16 x i16> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i16> %10, <16 x i16> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i16> @_Z31sub_group_non_uniform_broadcastDv4_sj(<4 x i16> %11, i32 0) #7
+  %13 = shufflevector <4 x i16> %12, <4 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i16> %13, <16 x i16> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i16> %14, <16 x i16> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i16> @_Z31sub_group_non_uniform_broadcastDv8_sj(<8 x i16> %15, i32 0) #7
+  %17 = shufflevector <8 x i16> %16, <8 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i16> %17, <16 x i16> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i16> @_Z31sub_group_non_uniform_broadcastDv16_sj(<16 x i16> %18, i32 0) #7
+  %20 = extractelement <16 x i16> %19, i64 0
+  %21 = tail call spir_func signext i16 @_Z25sub_group_broadcast_firsts(i16 signext %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z31sub_group_non_uniform_broadcastsj(i16 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i16> @_Z31sub_group_non_uniform_broadcastDv2_sj(<2 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i16> @_Z31sub_group_non_uniform_broadcastDv3_sj(<3 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i16> @_Z31sub_group_non_uniform_broadcastDv4_sj(<4 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i16> @_Z31sub_group_non_uniform_broadcastDv8_sj(<8 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i16> @_Z31sub_group_non_uniform_broadcastDv16_sj(<16 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z25sub_group_broadcast_firsts(i16 signext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short2]] [[short2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short2]] {{[0-9]+}} [[ScopeSubgroup]] [[short2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short3]] [[short3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short3]] {{[0-9]+}} [[ScopeSubgroup]] [[short3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short4]] [[short4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short4]] {{[0-9]+}} [[ScopeSubgroup]] [[short4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short8]] [[short8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short8]] {{[0-9]+}} [[ScopeSubgroup]] [[short8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[short16]] [[short16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[short16]] {{[0-9]+}} [[ScopeSubgroup]] [[short16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[short]] [[short_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastUShorts
+; CHECK-LLVM: call spir_func i16 @_Z31sub_group_non_uniform_broadcasttj(i16 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i16> @_Z31sub_group_non_uniform_broadcastDv2_tj(<2 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i16> @_Z31sub_group_non_uniform_broadcastDv3_tj(<3 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i16> @_Z31sub_group_non_uniform_broadcastDv4_tj(<4 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i16> @_Z31sub_group_non_uniform_broadcastDv8_tj(<8 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i16> @_Z31sub_group_non_uniform_broadcastDv16_tj(<16 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func i16 @_Z25sub_group_broadcast_firstt(i16 {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastUShorts() local_unnamed_addr #2 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func zeroext i16 @_Z31sub_group_non_uniform_broadcasttj(i16 zeroext 0, i32 0) #7
+  %2 = insertelement <16 x i16> <i16 undef, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0>, i16 %1, i64 0
+  %3 = shufflevector <16 x i16> %2, <16 x i16> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i16> @_Z31sub_group_non_uniform_broadcastDv2_tj(<2 x i16> %3, i32 0) #7
+  %5 = shufflevector <2 x i16> %4, <2 x i16> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i16> %5, <16 x i16> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i16> %6, <16 x i16> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i16> @_Z31sub_group_non_uniform_broadcastDv3_tj(<3 x i16> %7, i32 0) #7
+  %9 = shufflevector <3 x i16> %8, <3 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i16> %9, <16 x i16> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i16> %10, <16 x i16> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i16> @_Z31sub_group_non_uniform_broadcastDv4_tj(<4 x i16> %11, i32 0) #7
+  %13 = shufflevector <4 x i16> %12, <4 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i16> %13, <16 x i16> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i16> %14, <16 x i16> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i16> @_Z31sub_group_non_uniform_broadcastDv8_tj(<8 x i16> %15, i32 0) #7
+  %17 = shufflevector <8 x i16> %16, <8 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i16> %17, <16 x i16> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i16> @_Z31sub_group_non_uniform_broadcastDv16_tj(<16 x i16> %18, i32 0) #7
+  %20 = extractelement <16 x i16> %19, i64 0
+  %21 = tail call spir_func zeroext i16 @_Z25sub_group_broadcast_firstt(i16 zeroext %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z31sub_group_non_uniform_broadcasttj(i16 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i16> @_Z31sub_group_non_uniform_broadcastDv2_tj(<2 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i16> @_Z31sub_group_non_uniform_broadcastDv3_tj(<3 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i16> @_Z31sub_group_non_uniform_broadcastDv4_tj(<4 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i16> @_Z31sub_group_non_uniform_broadcastDv8_tj(<8 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i16> @_Z31sub_group_non_uniform_broadcastDv16_tj(<16 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z25sub_group_broadcast_firstt(i16 zeroext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int2]] [[int2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int2]] {{[0-9]+}} [[ScopeSubgroup]] [[int2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int3]] [[int3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int3]] {{[0-9]+}} [[ScopeSubgroup]] [[int3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int4]] [[int4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int4]] {{[0-9]+}} [[ScopeSubgroup]] [[int4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int8]] [[int8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int8]] {{[0-9]+}} [[ScopeSubgroup]] [[int8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[int16]] [[int16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int16]] {{[0-9]+}} [[ScopeSubgroup]] [[int16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[int]] [[int_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastInts
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_broadcastjj(i32 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i32> @_Z31sub_group_non_uniform_broadcastDv2_jj(<2 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i32> @_Z31sub_group_non_uniform_broadcastDv3_jj(<3 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i32> @_Z31sub_group_non_uniform_broadcastDv4_jj(<4 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i32> @_Z31sub_group_non_uniform_broadcastDv8_jj(<8 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i32> @_Z31sub_group_non_uniform_broadcastDv16_jj(<16 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z25sub_group_broadcast_firstj(i32 {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastInts() local_unnamed_addr #3 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func i32 @_Z31sub_group_non_uniform_broadcastij(i32 0, i32 0) #7
+  %2 = insertelement <16 x i32> <i32 undef, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, i32 %1, i64 0
+  %3 = shufflevector <16 x i32> %2, <16 x i32> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i32> @_Z31sub_group_non_uniform_broadcastDv2_ij(<2 x i32> %3, i32 0) #7
+  %5 = shufflevector <2 x i32> %4, <2 x i32> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i32> %5, <16 x i32> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i32> %6, <16 x i32> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i32> @_Z31sub_group_non_uniform_broadcastDv3_ij(<3 x i32> %7, i32 0) #7
+  %9 = shufflevector <3 x i32> %8, <3 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i32> %9, <16 x i32> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i32> %10, <16 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i32> @_Z31sub_group_non_uniform_broadcastDv4_ij(<4 x i32> %11, i32 0) #7
+  %13 = shufflevector <4 x i32> %12, <4 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i32> %13, <16 x i32> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i32> %14, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i32> @_Z31sub_group_non_uniform_broadcastDv8_ij(<8 x i32> %15, i32 0) #7
+  %17 = shufflevector <8 x i32> %16, <8 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i32> %17, <16 x i32> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i32> @_Z31sub_group_non_uniform_broadcastDv16_ij(<16 x i32> %18, i32 0) #7
+  %20 = extractelement <16 x i32> %19, i64 0
+  %21 = tail call spir_func i32 @_Z25sub_group_broadcast_firsti(i32 %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_broadcastij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i32> @_Z31sub_group_non_uniform_broadcastDv2_ij(<2 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i32> @_Z31sub_group_non_uniform_broadcastDv3_ij(<3 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i32> @_Z31sub_group_non_uniform_broadcastDv4_ij(<4 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i32> @_Z31sub_group_non_uniform_broadcastDv8_ij(<8 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i32> @_Z31sub_group_non_uniform_broadcastDv16_ij(<16 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z25sub_group_broadcast_firsti(i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int2]] [[int2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int2]] {{[0-9]+}} [[ScopeSubgroup]] [[int2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int3]] [[int3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int3]] {{[0-9]+}} [[ScopeSubgroup]] [[int3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int4]] [[int4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int4]] {{[0-9]+}} [[ScopeSubgroup]] [[int4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int8]] [[int8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int8]] {{[0-9]+}} [[ScopeSubgroup]] [[int8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[int16]] [[int16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[int16]] {{[0-9]+}} [[ScopeSubgroup]] [[int16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[int]] [[int_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastUInts
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_broadcastjj(i32 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i32> @_Z31sub_group_non_uniform_broadcastDv2_jj(<2 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i32> @_Z31sub_group_non_uniform_broadcastDv3_jj(<3 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i32> @_Z31sub_group_non_uniform_broadcastDv4_jj(<4 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i32> @_Z31sub_group_non_uniform_broadcastDv8_jj(<8 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i32> @_Z31sub_group_non_uniform_broadcastDv16_jj(<16 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z25sub_group_broadcast_firstj(i32 {{.*}})
+
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastUInts() local_unnamed_addr #3 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func i32 @_Z31sub_group_non_uniform_broadcastjj(i32 0, i32 0) #7
+  %2 = insertelement <16 x i32> <i32 undef, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, i32 %1, i64 0
+  %3 = shufflevector <16 x i32> %2, <16 x i32> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i32> @_Z31sub_group_non_uniform_broadcastDv2_jj(<2 x i32> %3, i32 0) #7
+  %5 = shufflevector <2 x i32> %4, <2 x i32> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i32> %5, <16 x i32> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i32> %6, <16 x i32> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i32> @_Z31sub_group_non_uniform_broadcastDv3_jj(<3 x i32> %7, i32 0) #7
+  %9 = shufflevector <3 x i32> %8, <3 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i32> %9, <16 x i32> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i32> %10, <16 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i32> @_Z31sub_group_non_uniform_broadcastDv4_jj(<4 x i32> %11, i32 0) #7
+  %13 = shufflevector <4 x i32> %12, <4 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i32> %13, <16 x i32> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i32> %14, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i32> @_Z31sub_group_non_uniform_broadcastDv8_jj(<8 x i32> %15, i32 0) #7
+  %17 = shufflevector <8 x i32> %16, <8 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i32> %17, <16 x i32> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i32> @_Z31sub_group_non_uniform_broadcastDv16_jj(<16 x i32> %18, i32 0) #7
+  %20 = extractelement <16 x i32> %19, i64 0
+  %21 = tail call spir_func i32 @_Z25sub_group_broadcast_firstj(i32 %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_broadcastjj(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i32> @_Z31sub_group_non_uniform_broadcastDv2_jj(<2 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i32> @_Z31sub_group_non_uniform_broadcastDv3_jj(<3 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i32> @_Z31sub_group_non_uniform_broadcastDv4_jj(<4 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i32> @_Z31sub_group_non_uniform_broadcastDv8_jj(<8 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i32> @_Z31sub_group_non_uniform_broadcastDv16_jj(<16 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z25sub_group_broadcast_firstj(i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long2]] [[long2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long2]] {{[0-9]+}} [[ScopeSubgroup]] [[long2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long3]] [[long3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long3]] {{[0-9]+}} [[ScopeSubgroup]] [[long3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long4]] [[long4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long4]] {{[0-9]+}} [[ScopeSubgroup]] [[long4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long8]] [[long8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long8]] {{[0-9]+}} [[ScopeSubgroup]] [[long8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[long16]] [[long16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long16]] {{[0-9]+}} [[ScopeSubgroup]] [[long16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[long]] [[long_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastLongs
+; CHECK-LLVM: call spir_func i64 @_Z31sub_group_non_uniform_broadcastmj(i64 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i64> @_Z31sub_group_non_uniform_broadcastDv2_mj(<2 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i64> @_Z31sub_group_non_uniform_broadcastDv3_mj(<3 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i64> @_Z31sub_group_non_uniform_broadcastDv4_mj(<4 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i64> @_Z31sub_group_non_uniform_broadcastDv8_mj(<8 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i64> @_Z31sub_group_non_uniform_broadcastDv16_mj(<16 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func i64 @_Z25sub_group_broadcast_firstm(i64 {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastLongs() local_unnamed_addr #4 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func i64 @_Z31sub_group_non_uniform_broadcastlj(i64 0, i32 0) #7
+  %2 = insertelement <16 x i64> <i64 undef, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0>, i64 %1, i64 0
+  %3 = shufflevector <16 x i64> %2, <16 x i64> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i64> @_Z31sub_group_non_uniform_broadcastDv2_lj(<2 x i64> %3, i32 0) #7
+  %5 = shufflevector <2 x i64> %4, <2 x i64> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i64> %5, <16 x i64> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i64> %6, <16 x i64> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i64> @_Z31sub_group_non_uniform_broadcastDv3_lj(<3 x i64> %7, i32 0) #7
+  %9 = shufflevector <3 x i64> %8, <3 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i64> %9, <16 x i64> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i64> %10, <16 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i64> @_Z31sub_group_non_uniform_broadcastDv4_lj(<4 x i64> %11, i32 0) #7
+  %13 = shufflevector <4 x i64> %12, <4 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i64> %13, <16 x i64> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i64> %14, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i64> @_Z31sub_group_non_uniform_broadcastDv8_lj(<8 x i64> %15, i32 0) #7
+  %17 = shufflevector <8 x i64> %16, <8 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i64> %17, <16 x i64> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i64> @_Z31sub_group_non_uniform_broadcastDv16_lj(<16 x i64> %18, i32 0) #7
+  %20 = extractelement <16 x i64> %19, i64 0
+  %21 = tail call spir_func i64 @_Z25sub_group_broadcast_firstl(i64 %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z31sub_group_non_uniform_broadcastlj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i64> @_Z31sub_group_non_uniform_broadcastDv2_lj(<2 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i64> @_Z31sub_group_non_uniform_broadcastDv3_lj(<3 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i64> @_Z31sub_group_non_uniform_broadcastDv4_lj(<4 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i64> @_Z31sub_group_non_uniform_broadcastDv8_lj(<8 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i64> @_Z31sub_group_non_uniform_broadcastDv16_lj(<16 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z25sub_group_broadcast_firstl(i64) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long2]] [[long2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long2]] {{[0-9]+}} [[ScopeSubgroup]] [[long2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long3]] [[long3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long3]] {{[0-9]+}} [[ScopeSubgroup]] [[long3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long4]] [[long4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long4]] {{[0-9]+}} [[ScopeSubgroup]] [[long4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long8]] [[long8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long8]] {{[0-9]+}} [[ScopeSubgroup]] [[long8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[long16]] [[long16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[long16]] {{[0-9]+}} [[ScopeSubgroup]] [[long16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[long]] [[long_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastULongs
+; CHECK-LLVM: call spir_func i64 @_Z31sub_group_non_uniform_broadcastmj(i64 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i64> @_Z31sub_group_non_uniform_broadcastDv2_mj(<2 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i64> @_Z31sub_group_non_uniform_broadcastDv3_mj(<3 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i64> @_Z31sub_group_non_uniform_broadcastDv4_mj(<4 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i64> @_Z31sub_group_non_uniform_broadcastDv8_mj(<8 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i64> @_Z31sub_group_non_uniform_broadcastDv16_mj(<16 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func i64 @_Z25sub_group_broadcast_firstm(i64 {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastULongs() local_unnamed_addr #4 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func i64 @_Z31sub_group_non_uniform_broadcastmj(i64 0, i32 0) #7
+  %2 = insertelement <16 x i64> <i64 undef, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0>, i64 %1, i64 0
+  %3 = shufflevector <16 x i64> %2, <16 x i64> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i64> @_Z31sub_group_non_uniform_broadcastDv2_mj(<2 x i64> %3, i32 0) #7
+  %5 = shufflevector <2 x i64> %4, <2 x i64> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i64> %5, <16 x i64> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i64> %6, <16 x i64> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i64> @_Z31sub_group_non_uniform_broadcastDv3_mj(<3 x i64> %7, i32 0) #7
+  %9 = shufflevector <3 x i64> %8, <3 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i64> %9, <16 x i64> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i64> %10, <16 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i64> @_Z31sub_group_non_uniform_broadcastDv4_mj(<4 x i64> %11, i32 0) #7
+  %13 = shufflevector <4 x i64> %12, <4 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i64> %13, <16 x i64> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i64> %14, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i64> @_Z31sub_group_non_uniform_broadcastDv8_mj(<8 x i64> %15, i32 0) #7
+  %17 = shufflevector <8 x i64> %16, <8 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i64> %17, <16 x i64> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i64> @_Z31sub_group_non_uniform_broadcastDv16_mj(<16 x i64> %18, i32 0) #7
+  %20 = extractelement <16 x i64> %19, i64 0
+  %21 = tail call spir_func i64 @_Z25sub_group_broadcast_firstm(i64 %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z31sub_group_non_uniform_broadcastmj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i64> @_Z31sub_group_non_uniform_broadcastDv2_mj(<2 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i64> @_Z31sub_group_non_uniform_broadcastDv3_mj(<3 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i64> @_Z31sub_group_non_uniform_broadcastDv4_mj(<4 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i64> @_Z31sub_group_non_uniform_broadcastDv8_mj(<8 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i64> @_Z31sub_group_non_uniform_broadcastDv16_mj(<16 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z25sub_group_broadcast_firstm(i64) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[float]] {{[0-9]+}} [[ScopeSubgroup]] [[float_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[float2]] [[float2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[float2]] {{[0-9]+}} [[ScopeSubgroup]] [[float2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[float3]] [[float3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[float3]] {{[0-9]+}} [[ScopeSubgroup]] [[float3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[float4]] [[float4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[float4]] {{[0-9]+}} [[ScopeSubgroup]] [[float4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[float8]] [[float8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[float8]] {{[0-9]+}} [[ScopeSubgroup]] [[float8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[float16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[float16]] [[float16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[float16]] {{[0-9]+}} [[ScopeSubgroup]] [[float16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[float]] [[float_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[float]] {{[0-9]+}} [[ScopeSubgroup]] [[float_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastFloats
+; CHECK-LLVM: call spir_func float @_Z31sub_group_non_uniform_broadcastfj(float {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x float> @_Z31sub_group_non_uniform_broadcastDv2_fj(<2 x float> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x float> @_Z31sub_group_non_uniform_broadcastDv3_fj(<3 x float> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x float> @_Z31sub_group_non_uniform_broadcastDv4_fj(<4 x float> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x float> @_Z31sub_group_non_uniform_broadcastDv8_fj(<8 x float> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x float> @_Z31sub_group_non_uniform_broadcastDv16_fj(<16 x float> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func float @_Z25sub_group_broadcast_firstf(float {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastFloats() local_unnamed_addr #3 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func float @_Z31sub_group_non_uniform_broadcastfj(float 0.000000e+00, i32 0) #7
+  %2 = insertelement <16 x float> <float undef, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00>, float %1, i64 0
+  %3 = shufflevector <16 x float> %2, <16 x float> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x float> @_Z31sub_group_non_uniform_broadcastDv2_fj(<2 x float> %3, i32 0) #7
+  %5 = shufflevector <2 x float> %4, <2 x float> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x float> %5, <16 x float> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x float> %6, <16 x float> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x float> @_Z31sub_group_non_uniform_broadcastDv3_fj(<3 x float> %7, i32 0) #7
+  %9 = shufflevector <3 x float> %8, <3 x float> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x float> %9, <16 x float> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x float> %10, <16 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x float> @_Z31sub_group_non_uniform_broadcastDv4_fj(<4 x float> %11, i32 0) #7
+  %13 = shufflevector <4 x float> %12, <4 x float> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x float> %13, <16 x float> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x float> %14, <16 x float> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x float> @_Z31sub_group_non_uniform_broadcastDv8_fj(<8 x float> %15, i32 0) #7
+  %17 = shufflevector <8 x float> %16, <8 x float> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x float> %17, <16 x float> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x float> @_Z31sub_group_non_uniform_broadcastDv16_fj(<16 x float> %18, i32 0) #7
+  %20 = extractelement <16 x float> %19, i64 0
+  %21 = tail call spir_func float @_Z25sub_group_broadcast_firstf(float %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z31sub_group_non_uniform_broadcastfj(float, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x float> @_Z31sub_group_non_uniform_broadcastDv2_fj(<2 x float>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x float> @_Z31sub_group_non_uniform_broadcastDv3_fj(<3 x float>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x float> @_Z31sub_group_non_uniform_broadcastDv4_fj(<4 x float>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x float> @_Z31sub_group_non_uniform_broadcastDv8_fj(<8 x float>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x float> @_Z31sub_group_non_uniform_broadcastDv16_fj(<16 x float>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z25sub_group_broadcast_firstf(float) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[half]] {{[0-9]+}} [[ScopeSubgroup]] [[half_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[half2]] [[half2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[half2]] {{[0-9]+}} [[ScopeSubgroup]] [[half2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[half3]] [[half3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[half3]] {{[0-9]+}} [[ScopeSubgroup]] [[half3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[half4]] [[half4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[half4]] {{[0-9]+}} [[ScopeSubgroup]] [[half4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[half8]] [[half8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[half8]] {{[0-9]+}} [[ScopeSubgroup]] [[half8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[half16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[half16]] [[half16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[half16]] {{[0-9]+}} [[ScopeSubgroup]] [[half16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[half]] [[half_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[half]] {{[0-9]+}} [[ScopeSubgroup]] [[half_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastHalfs
+; CHECK-LLVM: call spir_func half @_Z31sub_group_non_uniform_broadcastDhj(half {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x half> @_Z31sub_group_non_uniform_broadcastDv2_Dhj(<2 x half> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x half> @_Z31sub_group_non_uniform_broadcastDv3_Dhj(<3 x half> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x half> @_Z31sub_group_non_uniform_broadcastDv4_Dhj(<4 x half> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x half> @_Z31sub_group_non_uniform_broadcastDv8_Dhj(<8 x half> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x half> @_Z31sub_group_non_uniform_broadcastDv16_Dhj(<16 x half> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func half @_Z25sub_group_broadcast_firstDh(half {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastHalfs() local_unnamed_addr #2 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func half @_Z31sub_group_non_uniform_broadcastDhj(half 0xH0000, i32 0) #7
+  %2 = insertelement <16 x half> <half undef, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000>, half %1, i64 0
+  %3 = shufflevector <16 x half> %2, <16 x half> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x half> @_Z31sub_group_non_uniform_broadcastDv2_Dhj(<2 x half> %3, i32 0) #7
+  %5 = shufflevector <2 x half> %4, <2 x half> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x half> %5, <16 x half> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x half> %6, <16 x half> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x half> @_Z31sub_group_non_uniform_broadcastDv3_Dhj(<3 x half> %7, i32 0) #7
+  %9 = shufflevector <3 x half> %8, <3 x half> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x half> %9, <16 x half> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x half> %10, <16 x half> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x half> @_Z31sub_group_non_uniform_broadcastDv4_Dhj(<4 x half> %11, i32 0) #7
+  %13 = shufflevector <4 x half> %12, <4 x half> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x half> %13, <16 x half> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x half> %14, <16 x half> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x half> @_Z31sub_group_non_uniform_broadcastDv8_Dhj(<8 x half> %15, i32 0) #7
+  %17 = shufflevector <8 x half> %16, <8 x half> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x half> %17, <16 x half> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x half> @_Z31sub_group_non_uniform_broadcastDv16_Dhj(<16 x half> %18, i32 0) #7
+  %20 = extractelement <16 x half> %19, i64 0
+  %21 = tail call spir_func half @_Z25sub_group_broadcast_firstDh(half %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z31sub_group_non_uniform_broadcastDhj(half, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x half> @_Z31sub_group_non_uniform_broadcastDv2_Dhj(<2 x half>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x half> @_Z31sub_group_non_uniform_broadcastDv3_Dhj(<3 x half>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x half> @_Z31sub_group_non_uniform_broadcastDv4_Dhj(<4 x half>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x half> @_Z31sub_group_non_uniform_broadcastDv8_Dhj(<8 x half>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x half> @_Z31sub_group_non_uniform_broadcastDv16_Dhj(<16 x half>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z25sub_group_broadcast_firstDh(half) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBroadcast [[double]] {{[0-9]+}} [[ScopeSubgroup]] [[double_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[double2]] [[double2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[double2]] {{[0-9]+}} [[ScopeSubgroup]] [[double2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[double3]] [[double3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[double3]] {{[0-9]+}} [[ScopeSubgroup]] [[double3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[double4]] [[double4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[double4]] {{[0-9]+}} [[ScopeSubgroup]] [[double4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[double8]] [[double8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[double8]] {{[0-9]+}} [[ScopeSubgroup]] [[double8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[double16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[double16]] [[double16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupNonUniformBroadcast [[double16]] {{[0-9]+}} [[ScopeSubgroup]] [[double16_0]] [[int_0]]
+; CHECK-SPIRV: CompositeExtract [[double]] [[double_value:[0-9]+]]
+; CHECK-SPIRV: GroupNonUniformBroadcastFirst [[double]] {{[0-9]+}} [[ScopeSubgroup]] [[double_value]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBroadcastDoubles
+; CHECK-LLVM: call spir_func double @_Z31sub_group_non_uniform_broadcastdj(double {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x double> @_Z31sub_group_non_uniform_broadcastDv2_dj(<2 x double> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x double> @_Z31sub_group_non_uniform_broadcastDv3_dj(<3 x double> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x double> @_Z31sub_group_non_uniform_broadcastDv4_dj(<4 x double> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x double> @_Z31sub_group_non_uniform_broadcastDv8_dj(<8 x double> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x double> @_Z31sub_group_non_uniform_broadcastDv16_dj(<16 x double> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func double @_Z25sub_group_broadcast_firstd(double {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBroadcastDoubles() local_unnamed_addr #4 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func double @_Z31sub_group_non_uniform_broadcastdj(double 0.000000e+00, i32 0) #7
+  %2 = insertelement <16 x double> <double undef, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00>, double %1, i64 0
+  %3 = shufflevector <16 x double> %2, <16 x double> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x double> @_Z31sub_group_non_uniform_broadcastDv2_dj(<2 x double> %3, i32 0) #7
+  %5 = shufflevector <2 x double> %4, <2 x double> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x double> %5, <16 x double> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x double> %6, <16 x double> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x double> @_Z31sub_group_non_uniform_broadcastDv3_dj(<3 x double> %7, i32 0) #7
+  %9 = shufflevector <3 x double> %8, <3 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x double> %9, <16 x double> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x double> %10, <16 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x double> @_Z31sub_group_non_uniform_broadcastDv4_dj(<4 x double> %11, i32 0) #7
+  %13 = shufflevector <4 x double> %12, <4 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x double> %13, <16 x double> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x double> %14, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x double> @_Z31sub_group_non_uniform_broadcastDv8_dj(<8 x double> %15, i32 0) #7
+  %17 = shufflevector <8 x double> %16, <8 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x double> %17, <16 x double> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x double> @_Z31sub_group_non_uniform_broadcastDv16_dj(<16 x double> %18, i32 0) #7
+  %20 = extractelement <16 x double> %19, i64 0
+  %21 = tail call spir_func double @_Z25sub_group_broadcast_firstd(double %20) #7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z31sub_group_non_uniform_broadcastdj(double, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x double> @_Z31sub_group_non_uniform_broadcastDv2_dj(<2 x double>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x double> @_Z31sub_group_non_uniform_broadcastDv3_dj(<3 x double>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x double> @_Z31sub_group_non_uniform_broadcastDv4_dj(<4 x double>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x double> @_Z31sub_group_non_uniform_broadcastDv8_dj(<8 x double>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x double> @_Z31sub_group_non_uniform_broadcastDv16_dj(<16 x double>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z25sub_group_broadcast_firstd(double) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBallot [[int4]] [[ballot:[0-9]+]] [[ScopeSubgroup]] [[false]]
+; CHECK-SPIRV: GroupNonUniformInverseBallot [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[ballot]]
+; CHECK-SPIRV: GroupNonUniformBallotBitExtract [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[ballot]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBallotBitCount [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[ballot]]
+; CHECK-SPIRV: GroupNonUniformBallotBitCount [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[ballot]]
+; CHECK-SPIRV: GroupNonUniformBallotBitCount [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[ballot]]
+; CHECK-SPIRV: GroupNonUniformBallotFindLSB [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[ballot]]
+; CHECK-SPIRV: GroupNonUniformBallotFindMSB [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[ballot]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBallotOperations
+; CHECK-LLVM: %[[ballot:[0-9]+]] = call spir_func <4 x i32> @_Z16sub_group_balloti(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z24sub_group_inverse_ballotDv4_j(<4 x i32> %[[ballot]])
+; CHECK-LLVM: call spir_func i32 @_Z28sub_group_ballot_bit_extractDv4_jj(<4 x i32> %[[ballot]], i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z26sub_group_ballot_bit_countDv4_j(<4 x i32> %[[ballot]])
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_ballot_inclusive_scanDv4_j(<4 x i32> %[[ballot]])
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_ballot_exclusive_scanDv4_j(<4 x i32> %[[ballot]])
+; CHECK-LLVM: call spir_func i32 @_Z25sub_group_ballot_find_lsbDv4_j(<4 x i32> %[[ballot]])
+; CHECK-LLVM: call spir_func i32 @_Z25sub_group_ballot_find_msbDv4_j(<4 x i32> %[[ballot]])
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBallotOperations(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
+  %2 = tail call spir_func <4 x i32> @_Z16sub_group_balloti(i32 0) #7
+  %3 = tail call spir_func i32 @_Z24sub_group_inverse_ballotDv4_j(<4 x i32> %2) #8
+  store i32 %3, i32 addrspace(1)* %0, align 4, !tbaa !8
+  %4 = tail call spir_func i32 @_Z28sub_group_ballot_bit_extractDv4_jj(<4 x i32> %2, i32 0) #8
+  %5 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %4, i32 addrspace(1)* %5, align 4, !tbaa !8
+  %6 = tail call spir_func i32 @_Z26sub_group_ballot_bit_countDv4_j(<4 x i32> %2) #8
+  %7 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %6, i32 addrspace(1)* %7, align 4, !tbaa !8
+  %8 = tail call spir_func i32 @_Z31sub_group_ballot_inclusive_scanDv4_j(<4 x i32> %2) #7
+  %9 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 3
+  store i32 %8, i32 addrspace(1)* %9, align 4, !tbaa !8
+  %10 = tail call spir_func i32 @_Z31sub_group_ballot_exclusive_scanDv4_j(<4 x i32> %2) #7
+  %11 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 4
+  store i32 %10, i32 addrspace(1)* %11, align 4, !tbaa !8
+  %12 = tail call spir_func i32 @_Z25sub_group_ballot_find_lsbDv4_j(<4 x i32> %2) #7
+  %13 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 5
+  store i32 %12, i32 addrspace(1)* %13, align 4, !tbaa !8
+  %14 = tail call spir_func i32 @_Z25sub_group_ballot_find_msbDv4_j(<4 x i32> %2) #7
+  %15 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 6
+  store i32 %14, i32 addrspace(1)* %15, align 4, !tbaa !8
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i32> @_Z16sub_group_balloti(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent nounwind readnone
+declare dso_local spir_func i32 @_Z24sub_group_inverse_ballotDv4_j(<4 x i32>) local_unnamed_addr #5
+
+; Function Attrs: convergent nounwind readnone
+declare dso_local spir_func i32 @_Z28sub_group_ballot_bit_extractDv4_jj(<4 x i32>, i32) local_unnamed_addr #5
+
+; Function Attrs: convergent nounwind readnone
+declare dso_local spir_func i32 @_Z26sub_group_ballot_bit_countDv4_j(<4 x i32>) local_unnamed_addr #5
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_ballot_inclusive_scanDv4_j(<4 x i32>) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_ballot_exclusive_scanDv4_j(<4 x i32>) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z25sub_group_ballot_find_lsbDv4_j(<4 x i32>) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z25sub_group_ballot_find_msbDv4_j(<4 x i32>) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: Load [[int4]] {{[0-9]+}} [[eqMask]]
+; CHECK-SPIRV: Load [[int4]] {{[0-9]+}} [[geMask]]
+; CHECK-SPIRV: Load [[int4]] {{[0-9]+}} [[gtMask]]
+; CHECK-SPIRV: Load [[int4]] {{[0-9]+}} [[leMask]]
+; CHECK-SPIRV: Load [[int4]] {{[0-9]+}} [[ltMask]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testSubgroupMasks
+; CHECK-LLVM: call spir_func <4 x i32> @_Z21get_sub_group_eq_maskv()
+; CHECK-LLVM: call spir_func <4 x i32> @_Z21get_sub_group_ge_maskv()
+; CHECK-LLVM: call spir_func <4 x i32> @_Z21get_sub_group_gt_maskv()
+; CHECK-LLVM: call spir_func <4 x i32> @_Z21get_sub_group_le_maskv()
+; CHECK-LLVM: call spir_func <4 x i32> @_Z21get_sub_group_lt_maskv()
+
+; Function Attrs: convergent nofree nounwind writeonly
+define dso_local spir_kernel void @testSubgroupMasks(<4 x i32> addrspace(1)* nocapture) local_unnamed_addr #6 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !12 !kernel_arg_base_type !13 !kernel_arg_type_qual !7 {
+  %2 = tail call spir_func <4 x i32> @_Z21get_sub_group_eq_maskv() #8
+  store <4 x i32> %2, <4 x i32> addrspace(1)* %0, align 16, !tbaa !14
+  %3 = tail call spir_func <4 x i32> @_Z21get_sub_group_ge_maskv() #8
+  %4 = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %0, i64 1
+  store <4 x i32> %3, <4 x i32> addrspace(1)* %4, align 16, !tbaa !14
+  %5 = tail call spir_func <4 x i32> @_Z21get_sub_group_gt_maskv() #8
+  %6 = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %0, i64 2
+  store <4 x i32> %5, <4 x i32> addrspace(1)* %6, align 16, !tbaa !14
+  %7 = tail call spir_func <4 x i32> @_Z21get_sub_group_le_maskv() #8
+  %8 = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %0, i64 3
+  store <4 x i32> %7, <4 x i32> addrspace(1)* %8, align 16, !tbaa !14
+  %9 = tail call spir_func <4 x i32> @_Z21get_sub_group_lt_maskv() #8
+  %10 = getelementptr inbounds <4 x i32>, <4 x i32> addrspace(1)* %0, i64 4
+  store <4 x i32> %9, <4 x i32> addrspace(1)* %10, align 16, !tbaa !14
+  ret void
+}
+
+; Function Attrs: convergent nounwind readnone
+declare dso_local spir_func <4 x i32> @_Z21get_sub_group_eq_maskv() local_unnamed_addr #5
+
+; Function Attrs: convergent nounwind readnone
+declare dso_local spir_func <4 x i32> @_Z21get_sub_group_ge_maskv() local_unnamed_addr #5
+
+; Function Attrs: convergent nounwind readnone
+declare dso_local spir_func <4 x i32> @_Z21get_sub_group_gt_maskv() local_unnamed_addr #5
+
+; Function Attrs: convergent nounwind readnone
+declare dso_local spir_func <4 x i32> @_Z21get_sub_group_le_maskv() local_unnamed_addr #5
+
+; Function Attrs: convergent nounwind readnone
+declare dso_local spir_func <4 x i32> @_Z21get_sub_group_lt_maskv() local_unnamed_addr #5
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="128" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="256" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="512" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="1024" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { convergent nounwind readnone "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { convergent nofree nounwind writeonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="128" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #7 = { convergent nounwind }
+attributes #8 = { convergent nounwind readnone }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.1 (https://github.com/llvm/llvm-project.git cb6d58d1dcf36a29ae5dd24ff891d6552f00bac7)"}
+!3 = !{}
+!4 = !{i32 1}
+!5 = !{!"none"}
+!6 = !{!"uint*"}
+!7 = !{!""}
+!8 = !{!9, !9, i64 0}
+!9 = !{!"int", !10, i64 0}
+!10 = !{!"omnipotent char", !11, i64 0}
+!11 = !{!"Simple C/C++ TBAA"}
+!12 = !{!"uint4*"}
+!13 = !{!"uint __attribute__((ext_vector_type(4)))*"}
+!14 = !{!10, !10, i64 0}

--- a/test/transcoding/sub_group_clustered_reduce.ll
+++ b/test/transcoding/sub_group_clustered_reduce.ll
@@ -1,0 +1,998 @@
+;; #pragma OPENCL EXTENSION cl_khr_subgroup_clustered_reduce : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+;; 
+;; kernel void testClusteredArithmeticChar(global char* dst)
+;; {
+;;     char v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredArithmeticUChar(global uchar* dst)
+;; {
+;;     uchar v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredArithmeticShort(global short* dst)
+;; {
+;;     short v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredArithmeticUShort(global ushort* dst)
+;; {
+;;     ushort v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredArithmeticInt(global int* dst)
+;; {
+;;     int v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredArithmeticUInt(global uint* dst)
+;; {
+;;     uint v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredArithmeticLong(global long* dst)
+;; {
+;;     long v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredArithmeticULong(global ulong* dst)
+;; {
+;;     ulong v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredArithmeticFloat(global float* dst)
+;; {
+;;     float v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredArithmeticHalf(global half* dst)
+;; {
+;;     half v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredArithmeticDouble(global double* dst)
+;; {
+;;     double v = 0;
+;;     dst[0] = sub_group_clustered_reduce_add(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_mul(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_min(v, 2);
+;;     dst[3] = sub_group_clustered_reduce_max(v, 2);
+;; }
+;; 
+;; kernel void testClusteredBitwiseChar(global char* dst)
+;; {
+;;     char v = 0;
+;;     dst[0] = sub_group_clustered_reduce_and(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_or(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_xor(v, 2);
+;; }
+;; 
+;; kernel void testClusteredBitwiseUChar(global uchar* dst)
+;; {
+;;     uchar v = 0;
+;;     dst[0] = sub_group_clustered_reduce_and(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_or(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_xor(v, 2);
+;; }
+;; 
+;; kernel void testClusteredBitwiseShort(global short* dst)
+;; {
+;;     short v = 0;
+;;     dst[0] = sub_group_clustered_reduce_and(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_or(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_xor(v, 2);
+;; }
+;; 
+;; kernel void testClusteredBitwiseUShort(global ushort* dst)
+;; {
+;;     ushort v = 0;
+;;     dst[0] = sub_group_clustered_reduce_and(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_or(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_xor(v, 2);
+;; }
+;; 
+;; kernel void testClusteredBitwiseInt(global int* dst)
+;; {
+;;     int v = 0;
+;;     dst[0] = sub_group_clustered_reduce_and(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_or(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_xor(v, 2);
+;; }
+;; 
+;; kernel void testClusteredBitwiseUInt(global uint* dst)
+;; {
+;;     uint v = 0;
+;;     dst[0] = sub_group_clustered_reduce_and(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_or(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_xor(v, 2);
+;; }
+;; 
+;; kernel void testClusteredBitwiseLong(global long* dst)
+;; {
+;;     long v = 0;
+;;     dst[0] = sub_group_clustered_reduce_and(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_or(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_xor(v, 2);
+;; }
+;; 
+;; kernel void testClusteredBitwiseULong(global ulong* dst)
+;; {
+;;     ulong v = 0;
+;;     dst[0] = sub_group_clustered_reduce_and(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_or(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_xor(v, 2);
+;; }
+;; 
+;; kernel void testClusteredLogical(global int* dst)
+;; {
+;;     int v = 0;
+;;     dst[0] = sub_group_clustered_reduce_logical_and(v, 2);
+;;     dst[1] = sub_group_clustered_reduce_logical_or(v, 2);
+;;     dst[2] = sub_group_clustered_reduce_logical_xor(v, 2);
+;; }
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; Change DISABLED to RUN once SPIRV->LLVM translation is implemented
+; DISABLED: llvm-spirv -r %t.spv -o %t.rev.bc
+; DISABLED: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: TypeBool  [[bool:[0-9]+]]
+; CHECK-SPIRV-DAG: TypeInt   [[char:[0-9]+]]   8  0
+; CHECK-SPIRV-DAG: TypeInt   [[short:[0-9]+]]  16 0
+; CHECK-SPIRV-DAG: TypeInt   [[int:[0-9]+]]    32 0
+; CHECK-SPIRV-DAG: TypeInt   [[long:[0-9]+]]   64 0
+; CHECK-SPIRV-DAG: TypeFloat [[half:[0-9]+]]   16
+; CHECK-SPIRV-DAG: TypeFloat [[float:[0-9]+]]  32
+; CHECK-SPIRV-DAG: TypeFloat [[double:[0-9]+]] 64
+
+; CHECK-SPIRV-DAG: ConstantFalse [[bool]] [[false:[0-9]+]]
+; CHECK-SPIRV-DAG: Constant [[int]]    [[ScopeSubgroup:[0-9]+]] 3
+; CHECK-SPIRV-DAG: Constant [[char]]   [[char_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[short]]  [[short_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[int]]    [[int_0:[0-9]+]]         0
+; CHECK-SPIRV-DAG: Constant [[int]]    [[int_2:[0-9]+]]         2
+; CHECK-SPIRV-DAG: Constant [[long]]   [[long_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[half]]   [[half_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[float]]  [[float_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[double]] [[double_0:[0-9]+]]      0
+
+; ModuleID = 'sub_group_clustered_reduce.cl'
+source_filename = "sub_group_clustered_reduce.cl"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformIMul [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformSMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformSMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticChar
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_addcj(i8 0, i32 2)
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_mulcj(i8 0, i32 2)
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_mincj(i8 0, i32 2)
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_maxcj(i8 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i8 @_Z30sub_group_clustered_reduce_addcj(i8 signext 0, i32 2) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func signext i8 @_Z30sub_group_clustered_reduce_mulcj(i8 signext 0, i32 2) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  %5 = tail call spir_func signext i8 @_Z30sub_group_clustered_reduce_mincj(i8 signext 0, i32 2) #2
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2
+  store i8 %5, i8 addrspace(1)* %6, align 1, !tbaa !7
+  %7 = tail call spir_func signext i8 @_Z30sub_group_clustered_reduce_maxcj(i8 signext 0, i32 2) #2
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 3
+  store i8 %7, i8 addrspace(1)* %8, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z30sub_group_clustered_reduce_addcj(i8 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z30sub_group_clustered_reduce_mulcj(i8 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z30sub_group_clustered_reduce_mincj(i8 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z30sub_group_clustered_reduce_maxcj(i8 signext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformIMul [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformUMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformUMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticUChar
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_addcj(i8 0, i32 2)
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_mulcj(i8 0, i32 2)
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_minhj(i8 0, i32 2)
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_maxhj(i8 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticUChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !10 !kernel_arg_base_type !10 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i8 @_Z30sub_group_clustered_reduce_addhj(i8 zeroext 0, i32 2) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func zeroext i8 @_Z30sub_group_clustered_reduce_mulhj(i8 zeroext 0, i32 2) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  %5 = tail call spir_func zeroext i8 @_Z30sub_group_clustered_reduce_minhj(i8 zeroext 0, i32 2) #2
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2
+  store i8 %5, i8 addrspace(1)* %6, align 1, !tbaa !7
+  %7 = tail call spir_func zeroext i8 @_Z30sub_group_clustered_reduce_maxhj(i8 zeroext 0, i32 2) #2
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 3
+  store i8 %7, i8 addrspace(1)* %8, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z30sub_group_clustered_reduce_addhj(i8 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z30sub_group_clustered_reduce_mulhj(i8 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z30sub_group_clustered_reduce_minhj(i8 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z30sub_group_clustered_reduce_maxhj(i8 zeroext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformIMul [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformSMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformSMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticShort
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_addsj(i16 0, i32 2)
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_mulsj(i16 0, i32 2)
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_minsj(i16 0, i32 2)
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_maxsj(i16 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !11 !kernel_arg_base_type !11 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i16 @_Z30sub_group_clustered_reduce_addsj(i16 signext 0, i32 2) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func signext i16 @_Z30sub_group_clustered_reduce_mulsj(i16 signext 0, i32 2) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  %5 = tail call spir_func signext i16 @_Z30sub_group_clustered_reduce_minsj(i16 signext 0, i32 2) #2
+  %6 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 2
+  store i16 %5, i16 addrspace(1)* %6, align 2, !tbaa !12
+  %7 = tail call spir_func signext i16 @_Z30sub_group_clustered_reduce_maxsj(i16 signext 0, i32 2) #2
+  %8 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 3
+  store i16 %7, i16 addrspace(1)* %8, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z30sub_group_clustered_reduce_addsj(i16 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z30sub_group_clustered_reduce_mulsj(i16 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z30sub_group_clustered_reduce_minsj(i16 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z30sub_group_clustered_reduce_maxsj(i16 signext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformIMul [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformUMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformUMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticUShort
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_addsj(i16 0, i32 2)
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_mulsj(i16 0, i32 2)
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_mintj(i16 0, i32 2)
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_maxtj(i16 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticUShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !14 !kernel_arg_base_type !14 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i16 @_Z30sub_group_clustered_reduce_addtj(i16 zeroext 0, i32 2) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func zeroext i16 @_Z30sub_group_clustered_reduce_multj(i16 zeroext 0, i32 2) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  %5 = tail call spir_func zeroext i16 @_Z30sub_group_clustered_reduce_mintj(i16 zeroext 0, i32 2) #2
+  %6 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 2
+  store i16 %5, i16 addrspace(1)* %6, align 2, !tbaa !12
+  %7 = tail call spir_func zeroext i16 @_Z30sub_group_clustered_reduce_maxtj(i16 zeroext 0, i32 2) #2
+  %8 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 3
+  store i16 %7, i16 addrspace(1)* %8, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z30sub_group_clustered_reduce_addtj(i16 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z30sub_group_clustered_reduce_multj(i16 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z30sub_group_clustered_reduce_mintj(i16 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z30sub_group_clustered_reduce_maxtj(i16 zeroext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformIMul [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformSMin [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformSMax [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticInt
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_addij(i32 0, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_mulij(i32 0, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_minij(i32 0, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_maxij(i32 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !15 !kernel_arg_base_type !15 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_addij(i32 0, i32 2) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_mulij(i32 0, i32 2) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  %5 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_minij(i32 0, i32 2) #2
+  %6 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %5, i32 addrspace(1)* %6, align 4, !tbaa !16
+  %7 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_maxij(i32 0, i32 2) #2
+  %8 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 3
+  store i32 %7, i32 addrspace(1)* %8, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_addij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_mulij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_minij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_maxij(i32, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformIMul [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformUMin [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformUMax [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticUInt
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_addij(i32 0, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_mulij(i32 0, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_minjj(i32 0, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_maxjj(i32 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticUInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !18 !kernel_arg_base_type !18 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_addjj(i32 0, i32 2) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_muljj(i32 0, i32 2) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  %5 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_minjj(i32 0, i32 2) #2
+  %6 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %5, i32 addrspace(1)* %6, align 4, !tbaa !16
+  %7 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_maxjj(i32 0, i32 2) #2
+  %8 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 3
+  store i32 %7, i32 addrspace(1)* %8, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_addjj(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_muljj(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_minjj(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_maxjj(i32, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformIMul [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformSMin [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformSMax [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticLong
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_addlj(i64 0, i32 2)
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_mullj(i64 0, i32 2)
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_minlj(i64 0, i32 2)
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_maxlj(i64 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticLong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !19 !kernel_arg_base_type !19 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_addlj(i64 0, i32 2) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_mullj(i64 0, i32 2) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  %5 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_minlj(i64 0, i32 2) #2
+  %6 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 2
+  store i64 %5, i64 addrspace(1)* %6, align 8, !tbaa !20
+  %7 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_maxlj(i64 0, i32 2) #2
+  %8 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 3
+  store i64 %7, i64 addrspace(1)* %8, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_addlj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_mullj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_minlj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_maxlj(i64, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformIMul [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformUMin [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformUMax [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticULong
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_addlj(i64 0, i32 2)
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_mullj(i64 0, i32 2)
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_minmj(i64 0, i32 2)
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_maxmj(i64 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticULong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !22 !kernel_arg_base_type !22 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_addmj(i64 0, i32 2) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_mulmj(i64 0, i32 2) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  %5 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_minmj(i64 0, i32 2) #2
+  %6 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 2
+  store i64 %5, i64 addrspace(1)* %6, align 8, !tbaa !20
+  %7 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_maxmj(i64 0, i32 2) #2
+  %8 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 3
+  store i64 %7, i64 addrspace(1)* %8, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_addmj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_mulmj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_minmj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_maxmj(i64, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformFAdd [[float]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[float_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformFMul [[float]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[float_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformFMin [[float]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[float_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformFMax [[float]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[float_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticFloat
+; CHECK-LLVM: call spir_func float @_Z30sub_group_clustered_reduce_addfj(float 0.000000e+00, i32 2)
+; CHECK-LLVM: call spir_func float @_Z30sub_group_clustered_reduce_mulfj(float 0.000000e+00, i32 2)
+; CHECK-LLVM: call spir_func float @_Z30sub_group_clustered_reduce_minfj(float 0.000000e+00, i32 2)
+; CHECK-LLVM: call spir_func float @_Z30sub_group_clustered_reduce_maxfj(float 0.000000e+00, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticFloat(float addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !23 !kernel_arg_base_type !23 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func float @_Z30sub_group_clustered_reduce_addfj(float 0.000000e+00, i32 2) #2
+  store float %2, float addrspace(1)* %0, align 4, !tbaa !24
+  %3 = tail call spir_func float @_Z30sub_group_clustered_reduce_mulfj(float 0.000000e+00, i32 2) #2
+  %4 = getelementptr inbounds float, float addrspace(1)* %0, i64 1
+  store float %3, float addrspace(1)* %4, align 4, !tbaa !24
+  %5 = tail call spir_func float @_Z30sub_group_clustered_reduce_minfj(float 0.000000e+00, i32 2) #2
+  %6 = getelementptr inbounds float, float addrspace(1)* %0, i64 2
+  store float %5, float addrspace(1)* %6, align 4, !tbaa !24
+  %7 = tail call spir_func float @_Z30sub_group_clustered_reduce_maxfj(float 0.000000e+00, i32 2) #2
+  %8 = getelementptr inbounds float, float addrspace(1)* %0, i64 3
+  store float %7, float addrspace(1)* %8, align 4, !tbaa !24
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z30sub_group_clustered_reduce_addfj(float, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z30sub_group_clustered_reduce_mulfj(float, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z30sub_group_clustered_reduce_minfj(float, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z30sub_group_clustered_reduce_maxfj(float, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformFAdd [[half]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[half_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformFMul [[half]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[half_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformFMin [[half]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[half_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformFMax [[half]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[half_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticHalf
+; CHECK-LLVM: call spir_func half @_Z30sub_group_clustered_reduce_addDhj(half 0xH0000, i32 2)
+; CHECK-LLVM: call spir_func half @_Z30sub_group_clustered_reduce_mulDhj(half 0xH0000, i32 2)
+; CHECK-LLVM: call spir_func half @_Z30sub_group_clustered_reduce_minDhj(half 0xH0000, i32 2)
+; CHECK-LLVM: call spir_func half @_Z30sub_group_clustered_reduce_maxDhj(half 0xH0000, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticHalf(half addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !26 !kernel_arg_base_type !26 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func half @_Z30sub_group_clustered_reduce_addDhj(half 0xH0000, i32 2) #2
+  store half %2, half addrspace(1)* %0, align 2, !tbaa !27
+  %3 = tail call spir_func half @_Z30sub_group_clustered_reduce_mulDhj(half 0xH0000, i32 2) #2
+  %4 = getelementptr inbounds half, half addrspace(1)* %0, i64 1
+  store half %3, half addrspace(1)* %4, align 2, !tbaa !27
+  %5 = tail call spir_func half @_Z30sub_group_clustered_reduce_minDhj(half 0xH0000, i32 2) #2
+  %6 = getelementptr inbounds half, half addrspace(1)* %0, i64 2
+  store half %5, half addrspace(1)* %6, align 2, !tbaa !27
+  %7 = tail call spir_func half @_Z30sub_group_clustered_reduce_maxDhj(half 0xH0000, i32 2) #2
+  %8 = getelementptr inbounds half, half addrspace(1)* %0, i64 3
+  store half %7, half addrspace(1)* %8, align 2, !tbaa !27
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z30sub_group_clustered_reduce_addDhj(half, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z30sub_group_clustered_reduce_mulDhj(half, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z30sub_group_clustered_reduce_minDhj(half, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z30sub_group_clustered_reduce_maxDhj(half, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformFAdd [[double]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[double_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformFMul [[double]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[double_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformFMin [[double]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[double_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformFMax [[double]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[double_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredArithmeticDouble
+; CHECK-LLVM: call spir_func double @_Z30sub_group_clustered_reduce_adddj(double 0.000000e+00, i32 2)
+; CHECK-LLVM: call spir_func double @_Z30sub_group_clustered_reduce_muldj(double 0.000000e+00, i32 2)
+; CHECK-LLVM: call spir_func double @_Z30sub_group_clustered_reduce_mindj(double 0.000000e+00, i32 2)
+; CHECK-LLVM: call spir_func double @_Z30sub_group_clustered_reduce_maxdj(double 0.000000e+00, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredArithmeticDouble(double addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !29 !kernel_arg_base_type !29 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func double @_Z30sub_group_clustered_reduce_adddj(double 0.000000e+00, i32 2) #2
+  store double %2, double addrspace(1)* %0, align 8, !tbaa !30
+  %3 = tail call spir_func double @_Z30sub_group_clustered_reduce_muldj(double 0.000000e+00, i32 2) #2
+  %4 = getelementptr inbounds double, double addrspace(1)* %0, i64 1
+  store double %3, double addrspace(1)* %4, align 8, !tbaa !30
+  %5 = tail call spir_func double @_Z30sub_group_clustered_reduce_mindj(double 0.000000e+00, i32 2) #2
+  %6 = getelementptr inbounds double, double addrspace(1)* %0, i64 2
+  store double %5, double addrspace(1)* %6, align 8, !tbaa !30
+  %7 = tail call spir_func double @_Z30sub_group_clustered_reduce_maxdj(double 0.000000e+00, i32 2) #2
+  %8 = getelementptr inbounds double, double addrspace(1)* %0, i64 3
+  store double %7, double addrspace(1)* %8, align 8, !tbaa !30
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z30sub_group_clustered_reduce_adddj(double, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z30sub_group_clustered_reduce_muldj(double, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z30sub_group_clustered_reduce_mindj(double, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z30sub_group_clustered_reduce_maxdj(double, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredBitwiseChar
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_andcj(i8 0, i32 2)
+; CHECK-LLVM: call spir_func i8 @_Z29sub_group_clustered_reduce_orcj(i8 0, i32 2)
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_xorcj(i8 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredBitwiseChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i8 @_Z30sub_group_clustered_reduce_andcj(i8 signext 0, i32 2) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func signext i8 @_Z29sub_group_clustered_reduce_orcj(i8 signext 0, i32 2) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  %5 = tail call spir_func signext i8 @_Z30sub_group_clustered_reduce_xorcj(i8 signext 0, i32 2) #2
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2
+  store i8 %5, i8 addrspace(1)* %6, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z30sub_group_clustered_reduce_andcj(i8 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z29sub_group_clustered_reduce_orcj(i8 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z30sub_group_clustered_reduce_xorcj(i8 signext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[char]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[char_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredBitwiseUChar
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_andcj(i8 0, i32 2)
+; CHECK-LLVM: call spir_func i8 @_Z29sub_group_clustered_reduce_orcj(i8 0, i32 2)
+; CHECK-LLVM: call spir_func i8 @_Z30sub_group_clustered_reduce_xorcj(i8 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredBitwiseUChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !10 !kernel_arg_base_type !10 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i8 @_Z30sub_group_clustered_reduce_andhj(i8 zeroext 0, i32 2) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func zeroext i8 @_Z29sub_group_clustered_reduce_orhj(i8 zeroext 0, i32 2) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  %5 = tail call spir_func zeroext i8 @_Z30sub_group_clustered_reduce_xorhj(i8 zeroext 0, i32 2) #2
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2
+  store i8 %5, i8 addrspace(1)* %6, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z30sub_group_clustered_reduce_andhj(i8 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z29sub_group_clustered_reduce_orhj(i8 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z30sub_group_clustered_reduce_xorhj(i8 zeroext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredBitwiseShort
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_andsj(i16 0, i32 2)
+; CHECK-LLVM: call spir_func i16 @_Z29sub_group_clustered_reduce_orsj(i16 0, i32 2)
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_xorsj(i16 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredBitwiseShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !11 !kernel_arg_base_type !11 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i16 @_Z30sub_group_clustered_reduce_andsj(i16 signext 0, i32 2) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func signext i16 @_Z29sub_group_clustered_reduce_orsj(i16 signext 0, i32 2) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  %5 = tail call spir_func signext i16 @_Z30sub_group_clustered_reduce_xorsj(i16 signext 0, i32 2) #2
+  %6 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 2
+  store i16 %5, i16 addrspace(1)* %6, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z30sub_group_clustered_reduce_andsj(i16 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z29sub_group_clustered_reduce_orsj(i16 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z30sub_group_clustered_reduce_xorsj(i16 signext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[short]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[short_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredBitwiseUShort
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_andsj(i16 0, i32 2)
+; CHECK-LLVM: call spir_func i16 @_Z29sub_group_clustered_reduce_orsj(i16 0, i32 2)
+; CHECK-LLVM: call spir_func i16 @_Z30sub_group_clustered_reduce_xorsj(i16 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredBitwiseUShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !14 !kernel_arg_base_type !14 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i16 @_Z30sub_group_clustered_reduce_andtj(i16 zeroext 0, i32 2) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func zeroext i16 @_Z29sub_group_clustered_reduce_ortj(i16 zeroext 0, i32 2) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  %5 = tail call spir_func zeroext i16 @_Z30sub_group_clustered_reduce_xortj(i16 zeroext 0, i32 2) #2
+  %6 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 2
+  store i16 %5, i16 addrspace(1)* %6, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z30sub_group_clustered_reduce_andtj(i16 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z29sub_group_clustered_reduce_ortj(i16 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z30sub_group_clustered_reduce_xortj(i16 zeroext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredBitwiseInt
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_andij(i32 0, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z29sub_group_clustered_reduce_orij(i32 0, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_xorij(i32 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredBitwiseInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !15 !kernel_arg_base_type !15 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_andij(i32 0, i32 2) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z29sub_group_clustered_reduce_orij(i32 0, i32 2) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  %5 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_xorij(i32 0, i32 2) #2
+  %6 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %5, i32 addrspace(1)* %6, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_andij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z29sub_group_clustered_reduce_orij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_xorij(i32, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[int]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[int_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredBitwiseUInt
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_andij(i32 0, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z29sub_group_clustered_reduce_orij(i32 0, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z30sub_group_clustered_reduce_xorij(i32 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredBitwiseUInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !18 !kernel_arg_base_type !18 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_andjj(i32 0, i32 2) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z29sub_group_clustered_reduce_orjj(i32 0, i32 2) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  %5 = tail call spir_func i32 @_Z30sub_group_clustered_reduce_xorjj(i32 0, i32 2) #2
+  %6 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %5, i32 addrspace(1)* %6, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_andjj(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z29sub_group_clustered_reduce_orjj(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_xorjj(i32, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredBitwiseLong
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_andlj(i64 0, i32 2)
+; CHECK-LLVM: call spir_func i64 @_Z29sub_group_clustered_reduce_orlj(i64 0, i32 2)
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_xorlj(i64 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredBitwiseLong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !19 !kernel_arg_base_type !19 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_andlj(i64 0, i32 2) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z29sub_group_clustered_reduce_orlj(i64 0, i32 2) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  %5 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_xorlj(i64 0, i32 2) #2
+  %6 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 2
+  store i64 %5, i64 addrspace(1)* %6, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_andlj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z29sub_group_clustered_reduce_orlj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_xorlj(i64, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[long]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[long_0]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredBitwiseULong
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_andlj(i64 0, i32 2)
+; CHECK-LLVM: call spir_func i64 @_Z29sub_group_clustered_reduce_orlj(i64 0, i32 2)
+; CHECK-LLVM: call spir_func i64 @_Z30sub_group_clustered_reduce_xorlj(i64 0, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredBitwiseULong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !22 !kernel_arg_base_type !22 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_andmj(i64 0, i32 2) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z29sub_group_clustered_reduce_ormj(i64 0, i32 2) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  %5 = tail call spir_func i64 @_Z30sub_group_clustered_reduce_xormj(i64 0, i32 2) #2
+  %6 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 2
+  store i64 %5, i64 addrspace(1)* %6, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_andmj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z29sub_group_clustered_reduce_ormj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_xormj(i64, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformLogicalAnd [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[false]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformLogicalOr  [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[false]] [[int_2]]
+; CHECK-SPIRV: GroupNonUniformLogicalXor [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 3 [[false]] [[int_2]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testClusteredLogical
+; CHECK-LLVM: call spir_func i32 @_Z38sub_group_clustered_reduce_logical_andij(i32 {{.*}}, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z37sub_group_clustered_reduce_logical_orij(i32 {{.*}}, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z38sub_group_clustered_reduce_logical_xorij(i32 {{.*}}, i32 2)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testClusteredLogical(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !15 !kernel_arg_base_type !15 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z38sub_group_clustered_reduce_logical_andij(i32 0, i32 2) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z37sub_group_clustered_reduce_logical_orij(i32 0, i32 2) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  %5 = tail call spir_func i32 @_Z38sub_group_clustered_reduce_logical_xorij(i32 0, i32 2) #2
+  %6 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %5, i32 addrspace(1)* %6, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z38sub_group_clustered_reduce_logical_andij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z37sub_group_clustered_reduce_logical_orij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z38sub_group_clustered_reduce_logical_xorij(i32, i32) local_unnamed_addr #1
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.1 (https://github.com/llvm/llvm-project.git cb6d58d1dcf36a29ae5dd24ff891d6552f00bac7)"}
+!3 = !{i32 1}
+!4 = !{!"none"}
+!5 = !{!"char*"}
+!6 = !{!""}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !{!"uchar*"}
+!11 = !{!"short*"}
+!12 = !{!13, !13, i64 0}
+!13 = !{!"short", !8, i64 0}
+!14 = !{!"ushort*"}
+!15 = !{!"int*"}
+!16 = !{!17, !17, i64 0}
+!17 = !{!"int", !8, i64 0}
+!18 = !{!"uint*"}
+!19 = !{!"long*"}
+!20 = !{!21, !21, i64 0}
+!21 = !{!"long", !8, i64 0}
+!22 = !{!"ulong*"}
+!23 = !{!"float*"}
+!24 = !{!25, !25, i64 0}
+!25 = !{!"float", !8, i64 0}
+!26 = !{!"half*"}
+!27 = !{!28, !28, i64 0}
+!28 = !{!"half", !8, i64 0}
+!29 = !{!"double*"}
+!30 = !{!31, !31, i64 0}
+!31 = !{!"double", !8, i64 0}

--- a/test/transcoding/sub_group_extended_types.ll
+++ b/test/transcoding/sub_group_extended_types.ll
@@ -1,0 +1,1322 @@
+;; #pragma OPENCL EXTENSION cl_khr_subgroup_extended_types : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+;; 
+;; kernel void testBroadcastChar()
+;; {
+;;     char16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testBroadcastUChar()
+;; {
+;;     uchar16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testBroadcastShort()
+;; {
+;;     short16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testBroadcastUShort()
+;; {
+;;     ushort16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testBroadcastInt()
+;; {
+;;     int16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testBroadcastUInt()
+;; {
+;;     uint16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testBroadcastLong()
+;; {
+;;     long16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testBroadcastULong()
+;; {
+;;     ulong16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testBroadcastFloat()
+;; {
+;;     float16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testBroadcastHalf()
+;; {
+;;     half16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testBroadcastDouble()
+;; {
+;;     double16 v = 0;
+;;     v.s0 = sub_group_broadcast(v.s0, 0);
+;;     v.s01 = sub_group_broadcast(v.s01, 0);
+;;     v.s012 = sub_group_broadcast(v.s012, 0);
+;;     v.s0123 = sub_group_broadcast(v.s0123, 0);
+;;     v.s01234567 = sub_group_broadcast(v.s01234567, 0);
+;;     v = sub_group_broadcast(v, 0);
+;; }
+;; 
+;; kernel void testReduceScanChar(global char* dst)
+;; {
+;;     char v = 0;
+;;     dst[0] = sub_group_reduce_add(v);
+;;     dst[1] = sub_group_reduce_min(v);
+;;     dst[2] = sub_group_reduce_max(v);
+;;     dst[3] = sub_group_scan_inclusive_add(v);
+;;     dst[4] = sub_group_scan_inclusive_min(v);
+;;     dst[5] = sub_group_scan_inclusive_max(v);
+;;     dst[6] = sub_group_scan_exclusive_add(v);
+;;     dst[7] = sub_group_scan_exclusive_min(v);
+;;     dst[8] = sub_group_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testReduceScanUChar(global uchar* dst)
+;; {
+;;     uchar v = 0;
+;;     dst[0] = sub_group_reduce_add(v);
+;;     dst[1] = sub_group_reduce_min(v);
+;;     dst[2] = sub_group_reduce_max(v);
+;;     dst[3] = sub_group_scan_inclusive_add(v);
+;;     dst[4] = sub_group_scan_inclusive_min(v);
+;;     dst[5] = sub_group_scan_inclusive_max(v);
+;;     dst[6] = sub_group_scan_exclusive_add(v);
+;;     dst[7] = sub_group_scan_exclusive_min(v);
+;;     dst[8] = sub_group_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testReduceScanShort(global short* dst)
+;; {
+;;     short v = 0;
+;;     dst[0] = sub_group_reduce_add(v);
+;;     dst[1] = sub_group_reduce_min(v);
+;;     dst[2] = sub_group_reduce_max(v);
+;;     dst[3] = sub_group_scan_inclusive_add(v);
+;;     dst[4] = sub_group_scan_inclusive_min(v);
+;;     dst[5] = sub_group_scan_inclusive_max(v);
+;;     dst[6] = sub_group_scan_exclusive_add(v);
+;;     dst[7] = sub_group_scan_exclusive_min(v);
+;;     dst[8] = sub_group_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testReduceScanUShort(global ushort* dst)
+;; {
+;;     ushort v = 0;
+;;     dst[0] = sub_group_reduce_add(v);
+;;     dst[1] = sub_group_reduce_min(v);
+;;     dst[2] = sub_group_reduce_max(v);
+;;     dst[3] = sub_group_scan_inclusive_add(v);
+;;     dst[4] = sub_group_scan_inclusive_min(v);
+;;     dst[5] = sub_group_scan_inclusive_max(v);
+;;     dst[6] = sub_group_scan_exclusive_add(v);
+;;     dst[7] = sub_group_scan_exclusive_min(v);
+;;     dst[8] = sub_group_scan_exclusive_max(v);
+;; }
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; Change DISABLED to RUN once SPIRV->LLVM translation is implemented
+; DISABLED: llvm-spirv -r %t.spv -o %t.rev.bc
+; DISABLED: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: TypeInt   [[char:[0-9]+]]   8  0
+; CHECK-SPIRV-DAG: TypeInt   [[short:[0-9]+]]  16 0
+; CHECK-SPIRV-DAG: TypeInt   [[int:[0-9]+]]    32 0
+; CHECK-SPIRV-DAG: TypeInt   [[long:[0-9]+]]   64 0
+; CHECK-SPIRV-DAG: TypeFloat [[half:[0-9]+]]   16
+; CHECK-SPIRV-DAG: TypeFloat [[float:[0-9]+]]  32
+; CHECK-SPIRV-DAG: TypeFloat [[double:[0-9]+]] 64
+
+; CHECK-SPIRV-DAG: TypeVector [[char2:[0-9]+]]  [[char]] 2
+; CHECK-SPIRV-DAG: TypeVector [[char3:[0-9]+]]  [[char]] 3
+; CHECK-SPIRV-DAG: TypeVector [[char4:[0-9]+]]  [[char]] 4
+; CHECK-SPIRV-DAG: TypeVector [[char8:[0-9]+]]  [[char]] 8
+; CHECK-SPIRV-DAG: TypeVector [[char16:[0-9]+]] [[char]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[short2:[0-9]+]]  [[short]] 2
+; CHECK-SPIRV-DAG: TypeVector [[short3:[0-9]+]]  [[short]] 3
+; CHECK-SPIRV-DAG: TypeVector [[short4:[0-9]+]]  [[short]] 4
+; CHECK-SPIRV-DAG: TypeVector [[short8:[0-9]+]]  [[short]] 8
+; CHECK-SPIRV-DAG: TypeVector [[short16:[0-9]+]] [[short]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[int2:[0-9]+]]  [[int]] 2
+; CHECK-SPIRV-DAG: TypeVector [[int3:[0-9]+]]  [[int]] 3
+; CHECK-SPIRV-DAG: TypeVector [[int4:[0-9]+]]  [[int]] 4
+; CHECK-SPIRV-DAG: TypeVector [[int8:[0-9]+]]  [[int]] 8
+; CHECK-SPIRV-DAG: TypeVector [[int16:[0-9]+]] [[int]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[long2:[0-9]+]]  [[long]] 2
+; CHECK-SPIRV-DAG: TypeVector [[long3:[0-9]+]]  [[long]] 3
+; CHECK-SPIRV-DAG: TypeVector [[long4:[0-9]+]]  [[long]] 4
+; CHECK-SPIRV-DAG: TypeVector [[long8:[0-9]+]]  [[long]] 8
+; CHECK-SPIRV-DAG: TypeVector [[long16:[0-9]+]] [[long]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[float2:[0-9]+]]  [[float]] 2
+; CHECK-SPIRV-DAG: TypeVector [[float3:[0-9]+]]  [[float]] 3
+; CHECK-SPIRV-DAG: TypeVector [[float4:[0-9]+]]  [[float]] 4
+; CHECK-SPIRV-DAG: TypeVector [[float8:[0-9]+]]  [[float]] 8
+; CHECK-SPIRV-DAG: TypeVector [[float16:[0-9]+]] [[float]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[half2:[0-9]+]]  [[half]] 2
+; CHECK-SPIRV-DAG: TypeVector [[half3:[0-9]+]]  [[half]] 3
+; CHECK-SPIRV-DAG: TypeVector [[half4:[0-9]+]]  [[half]] 4
+; CHECK-SPIRV-DAG: TypeVector [[half8:[0-9]+]]  [[half]] 8
+; CHECK-SPIRV-DAG: TypeVector [[half16:[0-9]+]] [[half]] 16
+
+; CHECK-SPIRV-DAG: TypeVector [[double2:[0-9]+]]  [[double]] 2
+; CHECK-SPIRV-DAG: TypeVector [[double3:[0-9]+]]  [[double]] 3
+; CHECK-SPIRV-DAG: TypeVector [[double4:[0-9]+]]  [[double]] 4
+; CHECK-SPIRV-DAG: TypeVector [[double8:[0-9]+]]  [[double]] 8
+; CHECK-SPIRV-DAG: TypeVector [[double16:[0-9]+]] [[double]] 16
+
+; CHECK-SPIRV-DAG: Constant [[int]]    [[ScopeSubgroup:[0-9]+]] 3
+; CHECK-SPIRV-DAG: Constant [[char]]   [[char_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[short]]  [[short_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[int]]    [[int_0:[0-9]+]]         0
+; CHECK-SPIRV-DAG: Constant [[long]]   [[long_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[half]]   [[half_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[float]]  [[float_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[double]] [[double_0:[0-9]+]]      0
+
+; ModuleID = 'sub_group_extended_types.cl'
+source_filename = "sub_group_extended_types.cl"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char2]] [[char2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[char2]] {{[0-9]+}} [[ScopeSubgroup]] [[char2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char3]] [[char3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[char3]] {{[0-9]+}} [[ScopeSubgroup]] [[char3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char4]] [[char4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[char4]] {{[0-9]+}} [[ScopeSubgroup]] [[char4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char8]] [[char8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[char8]] {{[0-9]+}} [[ScopeSubgroup]] [[char8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[char16]] [[char16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[char16]] {{[0-9]+}} [[ScopeSubgroup]] [[char16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastChar
+; CHECK-LLVM: call spir_func i8 @_Z19sub_group_broadcasthj(i8 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i8> @_Z19sub_group_broadcastDv2_hj(<2 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i8> @_Z19sub_group_broadcastDv3_hj(<3 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i8> @_Z19sub_group_broadcastDv4_hj(<4 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i8> @_Z19sub_group_broadcastDv8_hj(<8 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i8> @_Z19sub_group_broadcastDv16_hj(<16 x i8> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastChar() local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func signext i8 @_Z19sub_group_broadcastcj(i8 signext 0, i32 0) #6
+  %2 = insertelement <16 x i8> <i8 undef, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0>, i8 %1, i64 0
+  %3 = shufflevector <16 x i8> %2, <16 x i8> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i8> @_Z19sub_group_broadcastDv2_cj(<2 x i8> %3, i32 0) #6
+  %5 = shufflevector <2 x i8> %4, <2 x i8> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i8> %5, <16 x i8> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i8> %6, <16 x i8> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i8> @_Z19sub_group_broadcastDv3_cj(<3 x i8> %7, i32 0) #6
+  %9 = shufflevector <3 x i8> %8, <3 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i8> %9, <16 x i8> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i8> %10, <16 x i8> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i8> @_Z19sub_group_broadcastDv4_cj(<4 x i8> %11, i32 0) #6
+  %13 = shufflevector <4 x i8> %12, <4 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i8> %13, <16 x i8> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i8> %14, <16 x i8> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i8> @_Z19sub_group_broadcastDv8_cj(<8 x i8> %15, i32 0) #6
+  %17 = shufflevector <8 x i8> %16, <8 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i8> %17, <16 x i8> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i8> @_Z19sub_group_broadcastDv16_cj(<16 x i8> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z19sub_group_broadcastcj(i8 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i8> @_Z19sub_group_broadcastDv2_cj(<2 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i8> @_Z19sub_group_broadcastDv3_cj(<3 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i8> @_Z19sub_group_broadcastDv4_cj(<4 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i8> @_Z19sub_group_broadcastDv8_cj(<8 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i8> @_Z19sub_group_broadcastDv16_cj(<16 x i8>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char2]] [[char2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[char2]] {{[0-9]+}} [[ScopeSubgroup]] [[char2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char3]] [[char3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[char3]] {{[0-9]+}} [[ScopeSubgroup]] [[char3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char4]] [[char4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[char4]] {{[0-9]+}} [[ScopeSubgroup]] [[char4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char8]] [[char8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[char8]] {{[0-9]+}} [[ScopeSubgroup]] [[char8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[char16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[char16]] [[char16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[char16]] {{[0-9]+}} [[ScopeSubgroup]] [[char16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastUChar
+; CHECK-LLVM: call spir_func i8 @_Z19sub_group_broadcasthj(i8 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i8> @_Z19sub_group_broadcastDv2_hj(<2 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i8> @_Z19sub_group_broadcastDv3_hj(<3 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i8> @_Z19sub_group_broadcastDv4_hj(<4 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i8> @_Z19sub_group_broadcastDv8_hj(<8 x i8> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i8> @_Z19sub_group_broadcastDv16_hj(<16 x i8> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastUChar() local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func zeroext i8 @_Z19sub_group_broadcasthj(i8 zeroext 0, i32 0) #6
+  %2 = insertelement <16 x i8> <i8 undef, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0>, i8 %1, i64 0
+  %3 = shufflevector <16 x i8> %2, <16 x i8> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i8> @_Z19sub_group_broadcastDv2_hj(<2 x i8> %3, i32 0) #6
+  %5 = shufflevector <2 x i8> %4, <2 x i8> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i8> %5, <16 x i8> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i8> %6, <16 x i8> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i8> @_Z19sub_group_broadcastDv3_hj(<3 x i8> %7, i32 0) #6
+  %9 = shufflevector <3 x i8> %8, <3 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i8> %9, <16 x i8> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i8> %10, <16 x i8> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i8> @_Z19sub_group_broadcastDv4_hj(<4 x i8> %11, i32 0) #6
+  %13 = shufflevector <4 x i8> %12, <4 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i8> %13, <16 x i8> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i8> %14, <16 x i8> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i8> @_Z19sub_group_broadcastDv8_hj(<8 x i8> %15, i32 0) #6
+  %17 = shufflevector <8 x i8> %16, <8 x i8> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i8> %17, <16 x i8> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i8> @_Z19sub_group_broadcastDv16_hj(<16 x i8> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z19sub_group_broadcasthj(i8 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i8> @_Z19sub_group_broadcastDv2_hj(<2 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i8> @_Z19sub_group_broadcastDv3_hj(<3 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i8> @_Z19sub_group_broadcastDv4_hj(<4 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i8> @_Z19sub_group_broadcastDv8_hj(<8 x i8>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i8> @_Z19sub_group_broadcastDv16_hj(<16 x i8>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short2]] [[short2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[short2]] {{[0-9]+}} [[ScopeSubgroup]] [[short2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short3]] [[short3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[short3]] {{[0-9]+}} [[ScopeSubgroup]] [[short3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short4]] [[short4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[short4]] {{[0-9]+}} [[ScopeSubgroup]] [[short4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short8]] [[short8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[short8]] {{[0-9]+}} [[ScopeSubgroup]] [[short8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[short16]] [[short16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[short16]] {{[0-9]+}} [[ScopeSubgroup]] [[short16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastShort
+; CHECK-LLVM: call spir_func i16 @_Z19sub_group_broadcasttj(i16 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i16> @_Z19sub_group_broadcastDv2_tj(<2 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i16> @_Z19sub_group_broadcastDv3_tj(<3 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i16> @_Z19sub_group_broadcastDv4_tj(<4 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i16> @_Z19sub_group_broadcastDv8_tj(<8 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i16> @_Z19sub_group_broadcastDv16_tj(<16 x i16> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastShort() local_unnamed_addr #2 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func signext i16 @_Z19sub_group_broadcastsj(i16 signext 0, i32 0) #6
+  %2 = insertelement <16 x i16> <i16 undef, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0>, i16 %1, i64 0
+  %3 = shufflevector <16 x i16> %2, <16 x i16> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i16> @_Z19sub_group_broadcastDv2_sj(<2 x i16> %3, i32 0) #6
+  %5 = shufflevector <2 x i16> %4, <2 x i16> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i16> %5, <16 x i16> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i16> %6, <16 x i16> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i16> @_Z19sub_group_broadcastDv3_sj(<3 x i16> %7, i32 0) #6
+  %9 = shufflevector <3 x i16> %8, <3 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i16> %9, <16 x i16> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i16> %10, <16 x i16> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i16> @_Z19sub_group_broadcastDv4_sj(<4 x i16> %11, i32 0) #6
+  %13 = shufflevector <4 x i16> %12, <4 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i16> %13, <16 x i16> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i16> %14, <16 x i16> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i16> @_Z19sub_group_broadcastDv8_sj(<8 x i16> %15, i32 0) #6
+  %17 = shufflevector <8 x i16> %16, <8 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i16> %17, <16 x i16> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i16> @_Z19sub_group_broadcastDv16_sj(<16 x i16> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z19sub_group_broadcastsj(i16 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i16> @_Z19sub_group_broadcastDv2_sj(<2 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i16> @_Z19sub_group_broadcastDv3_sj(<3 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i16> @_Z19sub_group_broadcastDv4_sj(<4 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i16> @_Z19sub_group_broadcastDv8_sj(<8 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i16> @_Z19sub_group_broadcastDv16_sj(<16 x i16>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short2]] [[short2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[short2]] {{[0-9]+}} [[ScopeSubgroup]] [[short2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short3]] [[short3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[short3]] {{[0-9]+}} [[ScopeSubgroup]] [[short3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short4]] [[short4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[short4]] {{[0-9]+}} [[ScopeSubgroup]] [[short4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short8]] [[short8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[short8]] {{[0-9]+}} [[ScopeSubgroup]] [[short8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[short16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[short16]] [[short16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[short16]] {{[0-9]+}} [[ScopeSubgroup]] [[short16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastUShort
+; CHECK-LLVM: call spir_func i16 @_Z19sub_group_broadcasttj(i16 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i16> @_Z19sub_group_broadcastDv2_tj(<2 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i16> @_Z19sub_group_broadcastDv3_tj(<3 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i16> @_Z19sub_group_broadcastDv4_tj(<4 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i16> @_Z19sub_group_broadcastDv8_tj(<8 x i16> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i16> @_Z19sub_group_broadcastDv16_tj(<16 x i16> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastUShort() local_unnamed_addr #2 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func zeroext i16 @_Z19sub_group_broadcasttj(i16 zeroext 0, i32 0) #6
+  %2 = insertelement <16 x i16> <i16 undef, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0>, i16 %1, i64 0
+  %3 = shufflevector <16 x i16> %2, <16 x i16> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i16> @_Z19sub_group_broadcastDv2_tj(<2 x i16> %3, i32 0) #6
+  %5 = shufflevector <2 x i16> %4, <2 x i16> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i16> %5, <16 x i16> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i16> %6, <16 x i16> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i16> @_Z19sub_group_broadcastDv3_tj(<3 x i16> %7, i32 0) #6
+  %9 = shufflevector <3 x i16> %8, <3 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i16> %9, <16 x i16> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i16> %10, <16 x i16> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i16> @_Z19sub_group_broadcastDv4_tj(<4 x i16> %11, i32 0) #6
+  %13 = shufflevector <4 x i16> %12, <4 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i16> %13, <16 x i16> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i16> %14, <16 x i16> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i16> @_Z19sub_group_broadcastDv8_tj(<8 x i16> %15, i32 0) #6
+  %17 = shufflevector <8 x i16> %16, <8 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i16> %17, <16 x i16> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i16> @_Z19sub_group_broadcastDv16_tj(<16 x i16> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z19sub_group_broadcasttj(i16 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i16> @_Z19sub_group_broadcastDv2_tj(<2 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i16> @_Z19sub_group_broadcastDv3_tj(<3 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i16> @_Z19sub_group_broadcastDv4_tj(<4 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i16> @_Z19sub_group_broadcastDv8_tj(<8 x i16>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i16> @_Z19sub_group_broadcastDv16_tj(<16 x i16>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int2]] [[int2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[int2]] {{[0-9]+}} [[ScopeSubgroup]] [[int2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int3]] [[int3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[int3]] {{[0-9]+}} [[ScopeSubgroup]] [[int3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int4]] [[int4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[int4]] {{[0-9]+}} [[ScopeSubgroup]] [[int4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int8]] [[int8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[int8]] {{[0-9]+}} [[ScopeSubgroup]] [[int8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[int16]] [[int16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[int16]] {{[0-9]+}} [[ScopeSubgroup]] [[int16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastInt
+; CHECK-LLVM: call spir_func i32 @_Z19sub_group_broadcastjj(i32 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i32> @_Z19sub_group_broadcastDv2_jj(<2 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i32> @_Z19sub_group_broadcastDv3_jj(<3 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i32> @_Z19sub_group_broadcastDv4_jj(<4 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i32> @_Z19sub_group_broadcastDv8_jj(<8 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i32> @_Z19sub_group_broadcastDv16_jj(<16 x i32> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastInt() local_unnamed_addr #3 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func i32 @_Z19sub_group_broadcastij(i32 0, i32 0) #6
+  %2 = insertelement <16 x i32> <i32 undef, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, i32 %1, i64 0
+  %3 = shufflevector <16 x i32> %2, <16 x i32> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i32> @_Z19sub_group_broadcastDv2_ij(<2 x i32> %3, i32 0) #6
+  %5 = shufflevector <2 x i32> %4, <2 x i32> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i32> %5, <16 x i32> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i32> %6, <16 x i32> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i32> @_Z19sub_group_broadcastDv3_ij(<3 x i32> %7, i32 0) #6
+  %9 = shufflevector <3 x i32> %8, <3 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i32> %9, <16 x i32> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i32> %10, <16 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i32> @_Z19sub_group_broadcastDv4_ij(<4 x i32> %11, i32 0) #6
+  %13 = shufflevector <4 x i32> %12, <4 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i32> %13, <16 x i32> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i32> %14, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i32> @_Z19sub_group_broadcastDv8_ij(<8 x i32> %15, i32 0) #6
+  %17 = shufflevector <8 x i32> %16, <8 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i32> %17, <16 x i32> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i32> @_Z19sub_group_broadcastDv16_ij(<16 x i32> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z19sub_group_broadcastij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i32> @_Z19sub_group_broadcastDv2_ij(<2 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i32> @_Z19sub_group_broadcastDv3_ij(<3 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i32> @_Z19sub_group_broadcastDv4_ij(<4 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i32> @_Z19sub_group_broadcastDv8_ij(<8 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i32> @_Z19sub_group_broadcastDv16_ij(<16 x i32>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int2]] [[int2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[int2]] {{[0-9]+}} [[ScopeSubgroup]] [[int2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int3]] [[int3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[int3]] {{[0-9]+}} [[ScopeSubgroup]] [[int3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int4]] [[int4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[int4]] {{[0-9]+}} [[ScopeSubgroup]] [[int4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int8]] [[int8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[int8]] {{[0-9]+}} [[ScopeSubgroup]] [[int8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[int16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[int16]] [[int16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[int16]] {{[0-9]+}} [[ScopeSubgroup]] [[int16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastUInt
+; CHECK-LLVM: call spir_func i32 @_Z19sub_group_broadcastjj(i32 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i32> @_Z19sub_group_broadcastDv2_jj(<2 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i32> @_Z19sub_group_broadcastDv3_jj(<3 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i32> @_Z19sub_group_broadcastDv4_jj(<4 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i32> @_Z19sub_group_broadcastDv8_jj(<8 x i32> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i32> @_Z19sub_group_broadcastDv16_jj(<16 x i32> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastUInt() local_unnamed_addr #3 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func i32 @_Z19sub_group_broadcastjj(i32 0, i32 0) #6
+  %2 = insertelement <16 x i32> <i32 undef, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, i32 %1, i64 0
+  %3 = shufflevector <16 x i32> %2, <16 x i32> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i32> @_Z19sub_group_broadcastDv2_jj(<2 x i32> %3, i32 0) #6
+  %5 = shufflevector <2 x i32> %4, <2 x i32> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i32> %5, <16 x i32> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i32> %6, <16 x i32> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i32> @_Z19sub_group_broadcastDv3_jj(<3 x i32> %7, i32 0) #6
+  %9 = shufflevector <3 x i32> %8, <3 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i32> %9, <16 x i32> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i32> %10, <16 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i32> @_Z19sub_group_broadcastDv4_jj(<4 x i32> %11, i32 0) #6
+  %13 = shufflevector <4 x i32> %12, <4 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i32> %13, <16 x i32> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i32> %14, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i32> @_Z19sub_group_broadcastDv8_jj(<8 x i32> %15, i32 0) #6
+  %17 = shufflevector <8 x i32> %16, <8 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i32> %17, <16 x i32> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i32> @_Z19sub_group_broadcastDv16_jj(<16 x i32> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z19sub_group_broadcastjj(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i32> @_Z19sub_group_broadcastDv2_jj(<2 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i32> @_Z19sub_group_broadcastDv3_jj(<3 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i32> @_Z19sub_group_broadcastDv4_jj(<4 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i32> @_Z19sub_group_broadcastDv8_jj(<8 x i32>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i32> @_Z19sub_group_broadcastDv16_jj(<16 x i32>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long2]] [[long2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[long2]] {{[0-9]+}} [[ScopeSubgroup]] [[long2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long3]] [[long3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[long3]] {{[0-9]+}} [[ScopeSubgroup]] [[long3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long4]] [[long4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[long4]] {{[0-9]+}} [[ScopeSubgroup]] [[long4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long8]] [[long8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[long8]] {{[0-9]+}} [[ScopeSubgroup]] [[long8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[long16]] [[long16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[long16]] {{[0-9]+}} [[ScopeSubgroup]] [[long16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastLong
+; CHECK-LLVM: call spir_func i64 @_Z19sub_group_broadcastmj(i64 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i64> @_Z19sub_group_broadcastDv2_mj(<2 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i64> @_Z19sub_group_broadcastDv3_mj(<3 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i64> @_Z19sub_group_broadcastDv4_mj(<4 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i64> @_Z19sub_group_broadcastDv8_mj(<8 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i64> @_Z19sub_group_broadcastDv16_mj(<16 x i64> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastLong() local_unnamed_addr #4 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func i64 @_Z19sub_group_broadcastlj(i64 0, i32 0) #6
+  %2 = insertelement <16 x i64> <i64 undef, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0>, i64 %1, i64 0
+  %3 = shufflevector <16 x i64> %2, <16 x i64> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i64> @_Z19sub_group_broadcastDv2_lj(<2 x i64> %3, i32 0) #6
+  %5 = shufflevector <2 x i64> %4, <2 x i64> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i64> %5, <16 x i64> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i64> %6, <16 x i64> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i64> @_Z19sub_group_broadcastDv3_lj(<3 x i64> %7, i32 0) #6
+  %9 = shufflevector <3 x i64> %8, <3 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i64> %9, <16 x i64> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i64> %10, <16 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i64> @_Z19sub_group_broadcastDv4_lj(<4 x i64> %11, i32 0) #6
+  %13 = shufflevector <4 x i64> %12, <4 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i64> %13, <16 x i64> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i64> %14, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i64> @_Z19sub_group_broadcastDv8_lj(<8 x i64> %15, i32 0) #6
+  %17 = shufflevector <8 x i64> %16, <8 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i64> %17, <16 x i64> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i64> @_Z19sub_group_broadcastDv16_lj(<16 x i64> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z19sub_group_broadcastlj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i64> @_Z19sub_group_broadcastDv2_lj(<2 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i64> @_Z19sub_group_broadcastDv3_lj(<3 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i64> @_Z19sub_group_broadcastDv4_lj(<4 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i64> @_Z19sub_group_broadcastDv8_lj(<8 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i64> @_Z19sub_group_broadcastDv16_lj(<16 x i64>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long2]] [[long2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[long2]] {{[0-9]+}} [[ScopeSubgroup]] [[long2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long3]] [[long3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[long3]] {{[0-9]+}} [[ScopeSubgroup]] [[long3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long4]] [[long4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[long4]] {{[0-9]+}} [[ScopeSubgroup]] [[long4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long8]] [[long8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[long8]] {{[0-9]+}} [[ScopeSubgroup]] [[long8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[long16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[long16]] [[long16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[long16]] {{[0-9]+}} [[ScopeSubgroup]] [[long16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastULong
+; CHECK-LLVM: call spir_func i64 @_Z19sub_group_broadcastmj(i64 {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x i64> @_Z19sub_group_broadcastDv2_mj(<2 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x i64> @_Z19sub_group_broadcastDv3_mj(<3 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x i64> @_Z19sub_group_broadcastDv4_mj(<4 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x i64> @_Z19sub_group_broadcastDv8_mj(<8 x i64> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x i64> @_Z19sub_group_broadcastDv16_mj(<16 x i64> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastULong() local_unnamed_addr #4 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func i64 @_Z19sub_group_broadcastmj(i64 0, i32 0) #6
+  %2 = insertelement <16 x i64> <i64 undef, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0>, i64 %1, i64 0
+  %3 = shufflevector <16 x i64> %2, <16 x i64> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x i64> @_Z19sub_group_broadcastDv2_mj(<2 x i64> %3, i32 0) #6
+  %5 = shufflevector <2 x i64> %4, <2 x i64> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x i64> %5, <16 x i64> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x i64> %6, <16 x i64> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x i64> @_Z19sub_group_broadcastDv3_mj(<3 x i64> %7, i32 0) #6
+  %9 = shufflevector <3 x i64> %8, <3 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x i64> %9, <16 x i64> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x i64> %10, <16 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x i64> @_Z19sub_group_broadcastDv4_mj(<4 x i64> %11, i32 0) #6
+  %13 = shufflevector <4 x i64> %12, <4 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x i64> %13, <16 x i64> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x i64> %14, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x i64> @_Z19sub_group_broadcastDv8_mj(<8 x i64> %15, i32 0) #6
+  %17 = shufflevector <8 x i64> %16, <8 x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x i64> %17, <16 x i64> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x i64> @_Z19sub_group_broadcastDv16_mj(<16 x i64> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z19sub_group_broadcastmj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x i64> @_Z19sub_group_broadcastDv2_mj(<2 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x i64> @_Z19sub_group_broadcastDv3_mj(<3 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x i64> @_Z19sub_group_broadcastDv4_mj(<4 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x i64> @_Z19sub_group_broadcastDv8_mj(<8 x i64>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x i64> @_Z19sub_group_broadcastDv16_mj(<16 x i64>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[float]] {{[0-9]+}} [[ScopeSubgroup]] [[float_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[float2]] [[float2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[float2]] {{[0-9]+}} [[ScopeSubgroup]] [[float2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[float3]] [[float3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[float3]] {{[0-9]+}} [[ScopeSubgroup]] [[float3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[float4]] [[float4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[float4]] {{[0-9]+}} [[ScopeSubgroup]] [[float4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[float8]] [[float8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[float8]] {{[0-9]+}} [[ScopeSubgroup]] [[float8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[float16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[float16]] [[float16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[float16]] {{[0-9]+}} [[ScopeSubgroup]] [[float16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastFloat
+; CHECK-LLVM: call spir_func float @_Z19sub_group_broadcastfj(float {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x float> @_Z19sub_group_broadcastDv2_fj(<2 x float> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x float> @_Z19sub_group_broadcastDv3_fj(<3 x float> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x float> @_Z19sub_group_broadcastDv4_fj(<4 x float> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x float> @_Z19sub_group_broadcastDv8_fj(<8 x float> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x float> @_Z19sub_group_broadcastDv16_fj(<16 x float> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastFloat() local_unnamed_addr #3 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func float @_Z19sub_group_broadcastfj(float 0.000000e+00, i32 0) #6
+  %2 = insertelement <16 x float> <float undef, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00>, float %1, i64 0
+  %3 = shufflevector <16 x float> %2, <16 x float> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x float> @_Z19sub_group_broadcastDv2_fj(<2 x float> %3, i32 0) #6
+  %5 = shufflevector <2 x float> %4, <2 x float> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x float> %5, <16 x float> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x float> %6, <16 x float> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x float> @_Z19sub_group_broadcastDv3_fj(<3 x float> %7, i32 0) #6
+  %9 = shufflevector <3 x float> %8, <3 x float> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x float> %9, <16 x float> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x float> %10, <16 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x float> @_Z19sub_group_broadcastDv4_fj(<4 x float> %11, i32 0) #6
+  %13 = shufflevector <4 x float> %12, <4 x float> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x float> %13, <16 x float> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x float> %14, <16 x float> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x float> @_Z19sub_group_broadcastDv8_fj(<8 x float> %15, i32 0) #6
+  %17 = shufflevector <8 x float> %16, <8 x float> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x float> %17, <16 x float> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x float> @_Z19sub_group_broadcastDv16_fj(<16 x float> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z19sub_group_broadcastfj(float, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x float> @_Z19sub_group_broadcastDv2_fj(<2 x float>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x float> @_Z19sub_group_broadcastDv3_fj(<3 x float>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x float> @_Z19sub_group_broadcastDv4_fj(<4 x float>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x float> @_Z19sub_group_broadcastDv8_fj(<8 x float>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x float> @_Z19sub_group_broadcastDv16_fj(<16 x float>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[half]] {{[0-9]+}} [[ScopeSubgroup]] [[half_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[half2]] [[half2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[half2]] {{[0-9]+}} [[ScopeSubgroup]] [[half2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[half3]] [[half3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[half3]] {{[0-9]+}} [[ScopeSubgroup]] [[half3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[half4]] [[half4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[half4]] {{[0-9]+}} [[ScopeSubgroup]] [[half4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[half8]] [[half8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[half8]] {{[0-9]+}} [[ScopeSubgroup]] [[half8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[half16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[half16]] [[half16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[half16]] {{[0-9]+}} [[ScopeSubgroup]] [[half16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastHalf
+; CHECK-LLVM: call spir_func half @_Z19sub_group_broadcastDhj(half {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x half> @_Z19sub_group_broadcastDv2_Dhj(<2 x half> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x half> @_Z19sub_group_broadcastDv3_Dhj(<3 x half> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x half> @_Z19sub_group_broadcastDv4_Dhj(<4 x half> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x half> @_Z19sub_group_broadcastDv8_Dhj(<8 x half> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x half> @_Z19sub_group_broadcastDv16_Dhj(<16 x half> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastHalf() local_unnamed_addr #2 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func half @_Z19sub_group_broadcastDhj(half 0xH0000, i32 0) #6
+  %2 = insertelement <16 x half> <half undef, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000, half 0xH0000>, half %1, i64 0
+  %3 = shufflevector <16 x half> %2, <16 x half> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x half> @_Z19sub_group_broadcastDv2_Dhj(<2 x half> %3, i32 0) #6
+  %5 = shufflevector <2 x half> %4, <2 x half> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x half> %5, <16 x half> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x half> %6, <16 x half> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x half> @_Z19sub_group_broadcastDv3_Dhj(<3 x half> %7, i32 0) #6
+  %9 = shufflevector <3 x half> %8, <3 x half> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x half> %9, <16 x half> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x half> %10, <16 x half> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x half> @_Z19sub_group_broadcastDv4_Dhj(<4 x half> %11, i32 0) #6
+  %13 = shufflevector <4 x half> %12, <4 x half> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x half> %13, <16 x half> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x half> %14, <16 x half> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x half> @_Z19sub_group_broadcastDv8_Dhj(<8 x half> %15, i32 0) #6
+  %17 = shufflevector <8 x half> %16, <8 x half> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x half> %17, <16 x half> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x half> @_Z19sub_group_broadcastDv16_Dhj(<16 x half> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z19sub_group_broadcastDhj(half, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x half> @_Z19sub_group_broadcastDv2_Dhj(<2 x half>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x half> @_Z19sub_group_broadcastDv3_Dhj(<3 x half>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x half> @_Z19sub_group_broadcastDv4_Dhj(<4 x half>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x half> @_Z19sub_group_broadcastDv8_Dhj(<8 x half>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x half> @_Z19sub_group_broadcastDv16_Dhj(<16 x half>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupBroadcast [[double]] {{[0-9]+}} [[ScopeSubgroup]] [[double_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[double2]] [[double2_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[double2]] {{[0-9]+}} [[ScopeSubgroup]] [[double2_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[double3]] [[double3_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[double3]] {{[0-9]+}} [[ScopeSubgroup]] [[double3_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[double4]] [[double4_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[double4]] {{[0-9]+}} [[ScopeSubgroup]] [[double4_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[double8]] [[double8_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[double8]] {{[0-9]+}} [[ScopeSubgroup]] [[double8_0]] [[int_0]]
+; CHECK-SPIRV: VectorShuffle [[double16]] {{[0-9]+}}
+; CHECK-SPIRV: VectorShuffle [[double16]] [[double16_0:[0-9]+]] 
+; CHECK-SPIRV: GroupBroadcast [[double16]] {{[0-9]+}} [[ScopeSubgroup]] [[double16_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testBroadcastDouble
+; CHECK-LLVM: call spir_func double @_Z19sub_group_broadcastdj(double {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <2 x double> @_Z19sub_group_broadcastDv2_dj(<2 x double> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <3 x double> @_Z19sub_group_broadcastDv3_dj(<3 x double> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <4 x double> @_Z19sub_group_broadcastDv4_dj(<4 x double> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <8 x double> @_Z19sub_group_broadcastDv8_dj(<8 x double> {{.*}}, i32 0)
+; CHECK-LLVM: call spir_func <16 x double> @_Z19sub_group_broadcastDv16_dj(<16 x double> {{.*}}, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testBroadcastDouble() local_unnamed_addr #4 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+  %1 = tail call spir_func double @_Z19sub_group_broadcastdj(double 0.000000e+00, i32 0) #6
+  %2 = insertelement <16 x double> <double undef, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00, double 0.000000e+00>, double %1, i64 0
+  %3 = shufflevector <16 x double> %2, <16 x double> undef, <2 x i32> <i32 0, i32 1>
+  %4 = tail call spir_func <2 x double> @_Z19sub_group_broadcastDv2_dj(<2 x double> %3, i32 0) #6
+  %5 = shufflevector <2 x double> %4, <2 x double> undef, <16 x i32> <i32 0, i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %6 = shufflevector <16 x double> %5, <16 x double> %2, <16 x i32> <i32 0, i32 1, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %7 = shufflevector <16 x double> %6, <16 x double> undef, <3 x i32> <i32 0, i32 1, i32 2>
+  %8 = tail call spir_func <3 x double> @_Z19sub_group_broadcastDv3_dj(<3 x double> %7, i32 0) #6
+  %9 = shufflevector <3 x double> %8, <3 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %10 = shufflevector <16 x double> %9, <16 x double> %6, <16 x i32> <i32 0, i32 1, i32 2, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %11 = shufflevector <16 x double> %10, <16 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %12 = tail call spir_func <4 x double> @_Z19sub_group_broadcastDv4_dj(<4 x double> %11, i32 0) #6
+  %13 = shufflevector <4 x double> %12, <4 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %14 = shufflevector <16 x double> %13, <16 x double> %10, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %15 = shufflevector <16 x double> %14, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %16 = tail call spir_func <8 x double> @_Z19sub_group_broadcastDv8_dj(<8 x double> %15, i32 0) #6
+  %17 = shufflevector <8 x double> %16, <8 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %18 = shufflevector <16 x double> %17, <16 x double> %14, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %19 = tail call spir_func <16 x double> @_Z19sub_group_broadcastDv16_dj(<16 x double> %18, i32 0) #6
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z19sub_group_broadcastdj(double, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <2 x double> @_Z19sub_group_broadcastDv2_dj(<2 x double>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <3 x double> @_Z19sub_group_broadcastDv3_dj(<3 x double>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <4 x double> @_Z19sub_group_broadcastDv4_dj(<4 x double>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <8 x double> @_Z19sub_group_broadcastDv8_dj(<8 x double>, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func <16 x double> @_Z19sub_group_broadcastDv16_dj(<16 x double>, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupSMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupSMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupSMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupSMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupSMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupSMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testReduceScanChar
+; CHECK-LLVM call spir_func i8 @_Z20sub_group_reduce_addc(i8 0)
+; CHECK-LLVM call spir_func i8 @_Z20sub_group_reduce_minc(i8 0)
+; CHECK-LLVM call spir_func i8 @_Z20sub_group_reduce_maxc(i8 0)
+; CHECK-LLVM call spir_func i8 @_Z28sub_group_scan_inclusive_addc(i8 0)
+; CHECK-LLVM call spir_func i8 @_Z28sub_group_scan_inclusive_minc(i8 0)
+; CHECK-LLVM call spir_func i8 @_Z28sub_group_scan_inclusive_maxc(i8 0)
+; CHECK-LLVM call spir_func i8 @_Z28sub_group_scan_exclusive_addc(i8 0)
+; CHECK-LLVM call spir_func i8 @_Z28sub_group_scan_exclusive_minc(i8 0)
+; CHECK-LLVM call spir_func i8 @_Z28sub_group_scan_exclusive_maxc(i8 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testReduceScanChar(i8 addrspace(1)* nocapture) local_unnamed_addr #5 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
+  %2 = tail call spir_func signext i8 @_Z20sub_group_reduce_addc(i8 signext 0) #6
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !8
+  %3 = tail call spir_func signext i8 @_Z20sub_group_reduce_minc(i8 signext 0) #6
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !8
+  %5 = tail call spir_func signext i8 @_Z20sub_group_reduce_maxc(i8 signext 0) #6
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2
+  store i8 %5, i8 addrspace(1)* %6, align 1, !tbaa !8
+  %7 = tail call spir_func signext i8 @_Z28sub_group_scan_inclusive_addc(i8 signext 0) #6
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 3
+  store i8 %7, i8 addrspace(1)* %8, align 1, !tbaa !8
+  %9 = tail call spir_func signext i8 @_Z28sub_group_scan_inclusive_minc(i8 signext 0) #6
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 4
+  store i8 %9, i8 addrspace(1)* %10, align 1, !tbaa !8
+  %11 = tail call spir_func signext i8 @_Z28sub_group_scan_inclusive_maxc(i8 signext 0) #6
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 5
+  store i8 %11, i8 addrspace(1)* %12, align 1, !tbaa !8
+  %13 = tail call spir_func signext i8 @_Z28sub_group_scan_exclusive_addc(i8 signext 0) #6
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 6
+  store i8 %13, i8 addrspace(1)* %14, align 1, !tbaa !8
+  %15 = tail call spir_func signext i8 @_Z28sub_group_scan_exclusive_minc(i8 signext 0) #6
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 7
+  store i8 %15, i8 addrspace(1)* %16, align 1, !tbaa !8
+  %17 = tail call spir_func signext i8 @_Z28sub_group_scan_exclusive_maxc(i8 signext 0) #6
+  %18 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 8
+  store i8 %17, i8 addrspace(1)* %18, align 1, !tbaa !8
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z20sub_group_reduce_addc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z20sub_group_reduce_minc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z20sub_group_reduce_maxc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z28sub_group_scan_inclusive_addc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z28sub_group_scan_inclusive_minc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z28sub_group_scan_inclusive_maxc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z28sub_group_scan_exclusive_addc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z28sub_group_scan_exclusive_minc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z28sub_group_scan_exclusive_maxc(i8 signext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupUMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupUMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupUMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupUMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupUMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupUMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testReduceScanUChar
+; CHECK-LLVM: call spir_func i8 @_Z20sub_group_reduce_addc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z20sub_group_reduce_minh(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z20sub_group_reduce_maxh(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z28sub_group_scan_inclusive_addc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z28sub_group_scan_inclusive_minh(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z28sub_group_scan_inclusive_maxh(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z28sub_group_scan_exclusive_addc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z28sub_group_scan_exclusive_minh(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z28sub_group_scan_exclusive_maxh(i8 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testReduceScanUChar(i8 addrspace(1)* nocapture) local_unnamed_addr #5 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !11 !kernel_arg_base_type !11 !kernel_arg_type_qual !7 {
+  %2 = tail call spir_func zeroext i8 @_Z20sub_group_reduce_addh(i8 zeroext 0) #6
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !8
+  %3 = tail call spir_func zeroext i8 @_Z20sub_group_reduce_minh(i8 zeroext 0) #6
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !8
+  %5 = tail call spir_func zeroext i8 @_Z20sub_group_reduce_maxh(i8 zeroext 0) #6
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2
+  store i8 %5, i8 addrspace(1)* %6, align 1, !tbaa !8
+  %7 = tail call spir_func zeroext i8 @_Z28sub_group_scan_inclusive_addh(i8 zeroext 0) #6
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 3
+  store i8 %7, i8 addrspace(1)* %8, align 1, !tbaa !8
+  %9 = tail call spir_func zeroext i8 @_Z28sub_group_scan_inclusive_minh(i8 zeroext 0) #6
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 4
+  store i8 %9, i8 addrspace(1)* %10, align 1, !tbaa !8
+  %11 = tail call spir_func zeroext i8 @_Z28sub_group_scan_inclusive_maxh(i8 zeroext 0) #6
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 5
+  store i8 %11, i8 addrspace(1)* %12, align 1, !tbaa !8
+  %13 = tail call spir_func zeroext i8 @_Z28sub_group_scan_exclusive_addh(i8 zeroext 0) #6
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 6
+  store i8 %13, i8 addrspace(1)* %14, align 1, !tbaa !8
+  %15 = tail call spir_func zeroext i8 @_Z28sub_group_scan_exclusive_minh(i8 zeroext 0) #6
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 7
+  store i8 %15, i8 addrspace(1)* %16, align 1, !tbaa !8
+  %17 = tail call spir_func zeroext i8 @_Z28sub_group_scan_exclusive_maxh(i8 zeroext 0) #6
+  %18 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 8
+  store i8 %17, i8 addrspace(1)* %18, align 1, !tbaa !8
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z20sub_group_reduce_addh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z20sub_group_reduce_minh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z20sub_group_reduce_maxh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z28sub_group_scan_inclusive_addh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z28sub_group_scan_inclusive_minh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z28sub_group_scan_inclusive_maxh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z28sub_group_scan_exclusive_addh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z28sub_group_scan_exclusive_minh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z28sub_group_scan_exclusive_maxh(i8 zeroext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupSMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupSMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupSMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupSMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupSMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupSMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testReduceScanShort
+; CHECK-LLVM: call spir_func i16 @_Z20sub_group_reduce_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z20sub_group_reduce_mins(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z20sub_group_reduce_maxs(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_inclusive_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_inclusive_mins(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_inclusive_maxs(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_exclusive_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_exclusive_mins(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_exclusive_maxs(i16 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testReduceScanShort(i16 addrspace(1)* nocapture) local_unnamed_addr #5 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !12 !kernel_arg_base_type !12 !kernel_arg_type_qual !7 {
+  %2 = tail call spir_func signext i16 @_Z20sub_group_reduce_adds(i16 signext 0) #6
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !13
+  %3 = tail call spir_func signext i16 @_Z20sub_group_reduce_mins(i16 signext 0) #6
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !13
+  %5 = tail call spir_func signext i16 @_Z20sub_group_reduce_maxs(i16 signext 0) #6
+  %6 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 2
+  store i16 %5, i16 addrspace(1)* %6, align 2, !tbaa !13
+  %7 = tail call spir_func signext i16 @_Z28sub_group_scan_inclusive_adds(i16 signext 0) #6
+  %8 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 3
+  store i16 %7, i16 addrspace(1)* %8, align 2, !tbaa !13
+  %9 = tail call spir_func signext i16 @_Z28sub_group_scan_inclusive_mins(i16 signext 0) #6
+  %10 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 4
+  store i16 %9, i16 addrspace(1)* %10, align 2, !tbaa !13
+  %11 = tail call spir_func signext i16 @_Z28sub_group_scan_inclusive_maxs(i16 signext 0) #6
+  %12 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 5
+  store i16 %11, i16 addrspace(1)* %12, align 2, !tbaa !13
+  %13 = tail call spir_func signext i16 @_Z28sub_group_scan_exclusive_adds(i16 signext 0) #6
+  %14 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 6
+  store i16 %13, i16 addrspace(1)* %14, align 2, !tbaa !13
+  %15 = tail call spir_func signext i16 @_Z28sub_group_scan_exclusive_mins(i16 signext 0) #6
+  %16 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 7
+  store i16 %15, i16 addrspace(1)* %16, align 2, !tbaa !13
+  %17 = tail call spir_func signext i16 @_Z28sub_group_scan_exclusive_maxs(i16 signext 0) #6
+  %18 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 8
+  store i16 %17, i16 addrspace(1)* %18, align 2, !tbaa !13
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z20sub_group_reduce_adds(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z20sub_group_reduce_mins(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z20sub_group_reduce_maxs(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z28sub_group_scan_inclusive_adds(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z28sub_group_scan_inclusive_mins(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z28sub_group_scan_inclusive_maxs(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z28sub_group_scan_exclusive_adds(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z28sub_group_scan_exclusive_mins(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z28sub_group_scan_exclusive_maxs(i16 signext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupUMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupUMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupUMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupUMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupUMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupUMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testReduceScanUShort
+; CHECK-LLVM: call spir_func i16 @_Z20sub_group_reduce_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z20sub_group_reduce_mint(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z20sub_group_reduce_maxt(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_inclusive_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_inclusive_mint(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_inclusive_maxt(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_exclusive_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_exclusive_mint(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z28sub_group_scan_exclusive_maxt(i16 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testReduceScanUShort(i16 addrspace(1)* nocapture) local_unnamed_addr #5 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !15 !kernel_arg_base_type !15 !kernel_arg_type_qual !7 {
+  %2 = tail call spir_func zeroext i16 @_Z20sub_group_reduce_addt(i16 zeroext 0) #6
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !13
+  %3 = tail call spir_func zeroext i16 @_Z20sub_group_reduce_mint(i16 zeroext 0) #6
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !13
+  %5 = tail call spir_func zeroext i16 @_Z20sub_group_reduce_maxt(i16 zeroext 0) #6
+  %6 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 2
+  store i16 %5, i16 addrspace(1)* %6, align 2, !tbaa !13
+  %7 = tail call spir_func zeroext i16 @_Z28sub_group_scan_inclusive_addt(i16 zeroext 0) #6
+  %8 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 3
+  store i16 %7, i16 addrspace(1)* %8, align 2, !tbaa !13
+  %9 = tail call spir_func zeroext i16 @_Z28sub_group_scan_inclusive_mint(i16 zeroext 0) #6
+  %10 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 4
+  store i16 %9, i16 addrspace(1)* %10, align 2, !tbaa !13
+  %11 = tail call spir_func zeroext i16 @_Z28sub_group_scan_inclusive_maxt(i16 zeroext 0) #6
+  %12 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 5
+  store i16 %11, i16 addrspace(1)* %12, align 2, !tbaa !13
+  %13 = tail call spir_func zeroext i16 @_Z28sub_group_scan_exclusive_addt(i16 zeroext 0) #6
+  %14 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 6
+  store i16 %13, i16 addrspace(1)* %14, align 2, !tbaa !13
+  %15 = tail call spir_func zeroext i16 @_Z28sub_group_scan_exclusive_mint(i16 zeroext 0) #6
+  %16 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 7
+  store i16 %15, i16 addrspace(1)* %16, align 2, !tbaa !13
+  %17 = tail call spir_func zeroext i16 @_Z28sub_group_scan_exclusive_maxt(i16 zeroext 0) #6
+  %18 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 8
+  store i16 %17, i16 addrspace(1)* %18, align 2, !tbaa !13
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z20sub_group_reduce_addt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z20sub_group_reduce_mint(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z20sub_group_reduce_maxt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z28sub_group_scan_inclusive_addt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z28sub_group_scan_inclusive_mint(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z28sub_group_scan_inclusive_maxt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z28sub_group_scan_exclusive_addt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z28sub_group_scan_exclusive_mint(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z28sub_group_scan_exclusive_maxt(i16 zeroext) local_unnamed_addr #1
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="128" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="256" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="512" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="1024" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { convergent nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.1 (https://github.com/llvm/llvm-project.git cb6d58d1dcf36a29ae5dd24ff891d6552f00bac7)"}
+!3 = !{}
+!4 = !{i32 1}
+!5 = !{!"none"}
+!6 = !{!"char*"}
+!7 = !{!""}
+!8 = !{!9, !9, i64 0}
+!9 = !{!"omnipotent char", !10, i64 0}
+!10 = !{!"Simple C/C++ TBAA"}
+!11 = !{!"uchar*"}
+!12 = !{!"short*"}
+!13 = !{!14, !14, i64 0}
+!14 = !{!"short", !9, i64 0}
+!15 = !{!"ushort*"}

--- a/test/transcoding/sub_group_non_uniform_arithmetic.ll
+++ b/test/transcoding/sub_group_non_uniform_arithmetic.ll
@@ -1,0 +1,2268 @@
+;; #pragma OPENCL EXTENSION cl_khr_subgroup_non_uniform_arithmetic : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+;; 
+;; kernel void testNonUniformArithmeticChar(global char* dst)
+;; {
+;;     char v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformArithmeticUChar(global uchar* dst)
+;; {
+;;     uchar v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformArithmeticShort(global short* dst)
+;; {
+;;     short v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformArithmeticUShort(global ushort* dst)
+;; {
+;;     ushort v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformArithmeticInt(global int* dst)
+;; {
+;;     int v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformArithmeticUInt(global uint* dst)
+;; {
+;;     uint v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformArithmeticLong(global long* dst)
+;; {
+;;     long v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformArithmeticULong(global ulong* dst)
+;; {
+;;     ulong v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformArithmeticFloat(global float* dst)
+;; {
+;;     float v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformArithmeticHalf(global half* dst)
+;; {
+;;     half v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformArithmeticDouble(global double* dst)
+;; {
+;;     double v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_add(v);
+;;     dst[1] = sub_group_non_uniform_reduce_mul(v);
+;;     dst[2] = sub_group_non_uniform_reduce_min(v);
+;;     dst[3] = sub_group_non_uniform_reduce_max(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_add(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_mul(v);
+;;     dst[6] = sub_group_non_uniform_scan_inclusive_min(v);
+;;     dst[7] = sub_group_non_uniform_scan_inclusive_max(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_add(v);
+;;     dst[9] = sub_group_non_uniform_scan_exclusive_mul(v);
+;;     dst[10] = sub_group_non_uniform_scan_exclusive_min(v);
+;;     dst[11] = sub_group_non_uniform_scan_exclusive_max(v);
+;; }
+;; 
+;; kernel void testNonUniformBitwiseChar(global char* dst)
+;; {
+;;     char v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_and(v);
+;;     dst[1] = sub_group_non_uniform_reduce_or(v);
+;;     dst[2] = sub_group_non_uniform_reduce_xor(v);
+;;     dst[3] = sub_group_non_uniform_scan_inclusive_and(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_or(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_xor(v);
+;;     dst[6] = sub_group_non_uniform_scan_exclusive_and(v);
+;;     dst[7] = sub_group_non_uniform_scan_exclusive_or(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_xor(v);
+;; }
+;; kernel void testNonUniformBitwiseUChar(global uchar* dst)
+;; {
+;;     uchar v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_and(v);
+;;     dst[1] = sub_group_non_uniform_reduce_or(v);
+;;     dst[2] = sub_group_non_uniform_reduce_xor(v);
+;;     dst[3] = sub_group_non_uniform_scan_inclusive_and(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_or(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_xor(v);
+;;     dst[6] = sub_group_non_uniform_scan_exclusive_and(v);
+;;     dst[7] = sub_group_non_uniform_scan_exclusive_or(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_xor(v);
+;; }
+;; kernel void testNonUniformBitwiseShort(global short* dst)
+;; {
+;;     short v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_and(v);
+;;     dst[1] = sub_group_non_uniform_reduce_or(v);
+;;     dst[2] = sub_group_non_uniform_reduce_xor(v);
+;;     dst[3] = sub_group_non_uniform_scan_inclusive_and(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_or(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_xor(v);
+;;     dst[6] = sub_group_non_uniform_scan_exclusive_and(v);
+;;     dst[7] = sub_group_non_uniform_scan_exclusive_or(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_xor(v);
+;; }
+;; kernel void testNonUniformBitwiseUShort(global ushort* dst)
+;; {
+;;     ushort v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_and(v);
+;;     dst[1] = sub_group_non_uniform_reduce_or(v);
+;;     dst[2] = sub_group_non_uniform_reduce_xor(v);
+;;     dst[3] = sub_group_non_uniform_scan_inclusive_and(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_or(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_xor(v);
+;;     dst[6] = sub_group_non_uniform_scan_exclusive_and(v);
+;;     dst[7] = sub_group_non_uniform_scan_exclusive_or(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_xor(v);
+;; }
+;; kernel void testNonUniformBitwiseInt(global int* dst)
+;; {
+;;     int v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_and(v);
+;;     dst[1] = sub_group_non_uniform_reduce_or(v);
+;;     dst[2] = sub_group_non_uniform_reduce_xor(v);
+;;     dst[3] = sub_group_non_uniform_scan_inclusive_and(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_or(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_xor(v);
+;;     dst[6] = sub_group_non_uniform_scan_exclusive_and(v);
+;;     dst[7] = sub_group_non_uniform_scan_exclusive_or(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_xor(v);
+;; }
+;; kernel void testNonUniformBitwiseUInt(global uint* dst)
+;; {
+;;     uint v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_and(v);
+;;     dst[1] = sub_group_non_uniform_reduce_or(v);
+;;     dst[2] = sub_group_non_uniform_reduce_xor(v);
+;;     dst[3] = sub_group_non_uniform_scan_inclusive_and(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_or(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_xor(v);
+;;     dst[6] = sub_group_non_uniform_scan_exclusive_and(v);
+;;     dst[7] = sub_group_non_uniform_scan_exclusive_or(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_xor(v);
+;; }
+;; kernel void testNonUniformBitwiseLong(global long* dst)
+;; {
+;;     long v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_and(v);
+;;     dst[1] = sub_group_non_uniform_reduce_or(v);
+;;     dst[2] = sub_group_non_uniform_reduce_xor(v);
+;;     dst[3] = sub_group_non_uniform_scan_inclusive_and(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_or(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_xor(v);
+;;     dst[6] = sub_group_non_uniform_scan_exclusive_and(v);
+;;     dst[7] = sub_group_non_uniform_scan_exclusive_or(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_xor(v);
+;; }
+;; kernel void testNonUniformBitwiseULong(global ulong* dst)
+;; {
+;;     ulong v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_and(v);
+;;     dst[1] = sub_group_non_uniform_reduce_or(v);
+;;     dst[2] = sub_group_non_uniform_reduce_xor(v);
+;;     dst[3] = sub_group_non_uniform_scan_inclusive_and(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_or(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_xor(v);
+;;     dst[6] = sub_group_non_uniform_scan_exclusive_and(v);
+;;     dst[7] = sub_group_non_uniform_scan_exclusive_or(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_xor(v);
+;; }
+;; 
+;; kernel void testNonUniformLogical(global int* dst)
+;; {
+;;     int v = 0;
+;;     dst[0] = sub_group_non_uniform_reduce_logical_and(v);
+;;     dst[1] = sub_group_non_uniform_reduce_logical_or(v);
+;;     dst[2] = sub_group_non_uniform_reduce_logical_xor(v);
+;;     dst[3] = sub_group_non_uniform_scan_inclusive_logical_and(v);
+;;     dst[4] = sub_group_non_uniform_scan_inclusive_logical_or(v);
+;;     dst[5] = sub_group_non_uniform_scan_inclusive_logical_xor(v);
+;;     dst[6] = sub_group_non_uniform_scan_exclusive_logical_and(v);
+;;     dst[7] = sub_group_non_uniform_scan_exclusive_logical_or(v);
+;;     dst[8] = sub_group_non_uniform_scan_exclusive_logical_xor(v);
+;; }
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; Change DISABLED to RUN once SPIRV->LLVM translation is implemented
+; DISABLED: llvm-spirv -r %t.spv -o %t.rev.bc
+; DISABLED: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: TypeBool  [[bool:[0-9]+]]
+; CHECK-SPIRV-DAG: TypeInt   [[char:[0-9]+]]   8  0
+; CHECK-SPIRV-DAG: TypeInt   [[short:[0-9]+]]  16 0
+; CHECK-SPIRV-DAG: TypeInt   [[int:[0-9]+]]    32 0
+; CHECK-SPIRV-DAG: TypeInt   [[long:[0-9]+]]   64 0
+; CHECK-SPIRV-DAG: TypeFloat [[half:[0-9]+]]   16
+; CHECK-SPIRV-DAG: TypeFloat [[float:[0-9]+]]  32
+; CHECK-SPIRV-DAG: TypeFloat [[double:[0-9]+]] 64
+
+; CHECK-SPIRV-DAG: ConstantFalse [[bool]] [[false:[0-9]+]]
+; CHECK-SPIRV-DAG: Constant [[int]]    [[ScopeSubgroup:[0-9]+]] 3
+; CHECK-SPIRV-DAG: Constant [[char]]   [[char_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[short]]  [[short_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[int]]    [[int_0:[0-9]+]]         0
+; CHECK-SPIRV-DAG: Constant [[long]]   [[long_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[half]]   [[half_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[float]]  [[float_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[double]] [[double_0:[0-9]+]]      0
+
+; ModuleID = 'sub_group_non_uniform_arithmetic.cl'
+source_filename = "sub_group_non_uniform_arithmetic.cl"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticChar
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_addc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_mulc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_minc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_maxc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_addc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_mulc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_minc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_maxc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_addc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_mulc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_minc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_maxc(i8 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i8 @_Z32sub_group_non_uniform_reduce_addc(i8 signext 0) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func signext i8 @_Z32sub_group_non_uniform_reduce_mulc(i8 signext 0) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  %5 = tail call spir_func signext i8 @_Z32sub_group_non_uniform_reduce_minc(i8 signext 0) #2
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2
+  store i8 %5, i8 addrspace(1)* %6, align 1, !tbaa !7
+  %7 = tail call spir_func signext i8 @_Z32sub_group_non_uniform_reduce_maxc(i8 signext 0) #2
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 3
+  store i8 %7, i8 addrspace(1)* %8, align 1, !tbaa !7
+  %9 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_addc(i8 signext 0) #2
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 4
+  store i8 %9, i8 addrspace(1)* %10, align 1, !tbaa !7
+  %11 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_mulc(i8 signext 0) #2
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 5
+  store i8 %11, i8 addrspace(1)* %12, align 1, !tbaa !7
+  %13 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_minc(i8 signext 0) #2
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 6
+  store i8 %13, i8 addrspace(1)* %14, align 1, !tbaa !7
+  %15 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_maxc(i8 signext 0) #2
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 7
+  store i8 %15, i8 addrspace(1)* %16, align 1, !tbaa !7
+  %17 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_addc(i8 signext 0) #2
+  %18 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 8
+  store i8 %17, i8 addrspace(1)* %18, align 1, !tbaa !7
+  %19 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_mulc(i8 signext 0) #2
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 9
+  store i8 %19, i8 addrspace(1)* %20, align 1, !tbaa !7
+  %21 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_minc(i8 signext 0) #2
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 10
+  store i8 %21, i8 addrspace(1)* %22, align 1, !tbaa !7
+  %23 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_maxc(i8 signext 0) #2
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 11
+  store i8 %23, i8 addrspace(1)* %24, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z32sub_group_non_uniform_reduce_addc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z32sub_group_non_uniform_reduce_mulc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z32sub_group_non_uniform_reduce_minc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z32sub_group_non_uniform_reduce_maxc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_addc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_mulc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_minc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_maxc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_addc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_mulc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_minc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_maxc(i8 signext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticUChar
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_addc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_mulc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_minh(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_maxh(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_addc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_mulc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_minh(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_maxh(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_addc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_mulc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_minh(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_maxh(i8 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticUChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !10 !kernel_arg_base_type !10 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_addh(i8 zeroext 0) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_mulh(i8 zeroext 0) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  %5 = tail call spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_minh(i8 zeroext 0) #2
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2
+  store i8 %5, i8 addrspace(1)* %6, align 1, !tbaa !7
+  %7 = tail call spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_maxh(i8 zeroext 0) #2
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 3
+  store i8 %7, i8 addrspace(1)* %8, align 1, !tbaa !7
+  %9 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_addh(i8 zeroext 0) #2
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 4
+  store i8 %9, i8 addrspace(1)* %10, align 1, !tbaa !7
+  %11 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_mulh(i8 zeroext 0) #2
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 5
+  store i8 %11, i8 addrspace(1)* %12, align 1, !tbaa !7
+  %13 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_minh(i8 zeroext 0) #2
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 6
+  store i8 %13, i8 addrspace(1)* %14, align 1, !tbaa !7
+  %15 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_maxh(i8 zeroext 0) #2
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 7
+  store i8 %15, i8 addrspace(1)* %16, align 1, !tbaa !7
+  %17 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_addh(i8 zeroext 0) #2
+  %18 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 8
+  store i8 %17, i8 addrspace(1)* %18, align 1, !tbaa !7
+  %19 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_mulh(i8 zeroext 0) #2
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 9
+  store i8 %19, i8 addrspace(1)* %20, align 1, !tbaa !7
+  %21 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_minh(i8 zeroext 0) #2
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 10
+  store i8 %21, i8 addrspace(1)* %22, align 1, !tbaa !7
+  %23 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_maxh(i8 zeroext 0) #2
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 11
+  store i8 %23, i8 addrspace(1)* %24, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_addh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_mulh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_minh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_maxh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_addh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_mulh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_minh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_maxh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_addh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_mulh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_minh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_maxh(i8 zeroext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticShort
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_muls(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_mins(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_maxs(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_muls(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_mins(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_maxs(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_muls(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_mins(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_maxs(i16 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !11 !kernel_arg_base_type !11 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i16 @_Z32sub_group_non_uniform_reduce_adds(i16 signext 0) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func signext i16 @_Z32sub_group_non_uniform_reduce_muls(i16 signext 0) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  %5 = tail call spir_func signext i16 @_Z32sub_group_non_uniform_reduce_mins(i16 signext 0) #2
+  %6 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 2
+  store i16 %5, i16 addrspace(1)* %6, align 2, !tbaa !12
+  %7 = tail call spir_func signext i16 @_Z32sub_group_non_uniform_reduce_maxs(i16 signext 0) #2
+  %8 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 3
+  store i16 %7, i16 addrspace(1)* %8, align 2, !tbaa !12
+  %9 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_adds(i16 signext 0) #2
+  %10 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 4
+  store i16 %9, i16 addrspace(1)* %10, align 2, !tbaa !12
+  %11 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_muls(i16 signext 0) #2
+  %12 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 5
+  store i16 %11, i16 addrspace(1)* %12, align 2, !tbaa !12
+  %13 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_mins(i16 signext 0) #2
+  %14 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 6
+  store i16 %13, i16 addrspace(1)* %14, align 2, !tbaa !12
+  %15 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_maxs(i16 signext 0) #2
+  %16 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 7
+  store i16 %15, i16 addrspace(1)* %16, align 2, !tbaa !12
+  %17 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_adds(i16 signext 0) #2
+  %18 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 8
+  store i16 %17, i16 addrspace(1)* %18, align 2, !tbaa !12
+  %19 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_muls(i16 signext 0) #2
+  %20 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 9
+  store i16 %19, i16 addrspace(1)* %20, align 2, !tbaa !12
+  %21 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_mins(i16 signext 0) #2
+  %22 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 10
+  store i16 %21, i16 addrspace(1)* %22, align 2, !tbaa !12
+  %23 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_maxs(i16 signext 0) #2
+  %24 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 11
+  store i16 %23, i16 addrspace(1)* %24, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z32sub_group_non_uniform_reduce_adds(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z32sub_group_non_uniform_reduce_muls(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z32sub_group_non_uniform_reduce_mins(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z32sub_group_non_uniform_reduce_maxs(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_adds(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_muls(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_mins(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_maxs(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_adds(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_muls(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_mins(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_maxs(i16 signext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticUShort
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_muls(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_mint(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_maxt(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_muls(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_mint(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_maxt(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_adds(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_muls(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_mint(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_maxt(i16 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticUShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !14 !kernel_arg_base_type !14 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_addt(i16 zeroext 0) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_mult(i16 zeroext 0) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  %5 = tail call spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_mint(i16 zeroext 0) #2
+  %6 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 2
+  store i16 %5, i16 addrspace(1)* %6, align 2, !tbaa !12
+  %7 = tail call spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_maxt(i16 zeroext 0) #2
+  %8 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 3
+  store i16 %7, i16 addrspace(1)* %8, align 2, !tbaa !12
+  %9 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_addt(i16 zeroext 0) #2
+  %10 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 4
+  store i16 %9, i16 addrspace(1)* %10, align 2, !tbaa !12
+  %11 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_mult(i16 zeroext 0) #2
+  %12 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 5
+  store i16 %11, i16 addrspace(1)* %12, align 2, !tbaa !12
+  %13 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_mint(i16 zeroext 0) #2
+  %14 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 6
+  store i16 %13, i16 addrspace(1)* %14, align 2, !tbaa !12
+  %15 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_maxt(i16 zeroext 0) #2
+  %16 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 7
+  store i16 %15, i16 addrspace(1)* %16, align 2, !tbaa !12
+  %17 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_addt(i16 zeroext 0) #2
+  %18 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 8
+  store i16 %17, i16 addrspace(1)* %18, align 2, !tbaa !12
+  %19 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_mult(i16 zeroext 0) #2
+  %20 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 9
+  store i16 %19, i16 addrspace(1)* %20, align 2, !tbaa !12
+  %21 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_mint(i16 zeroext 0) #2
+  %22 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 10
+  store i16 %21, i16 addrspace(1)* %22, align 2, !tbaa !12
+  %23 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_maxt(i16 zeroext 0) #2
+  %24 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 11
+  store i16 %23, i16 addrspace(1)* %24, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_addt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_mult(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_mint(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_maxt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_addt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_mult(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_mint(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_maxt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_addt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_mult(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_mint(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_maxt(i16 zeroext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticInt
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_addi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_muli(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_mini(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_maxi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_addi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_muli(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_mini(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_maxi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_addi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_muli(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_mini(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_maxi(i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !15 !kernel_arg_base_type !15 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_addi(i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_muli(i32 0) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  %5 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_mini(i32 0) #2
+  %6 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %5, i32 addrspace(1)* %6, align 4, !tbaa !16
+  %7 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_maxi(i32 0) #2
+  %8 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 3
+  store i32 %7, i32 addrspace(1)* %8, align 4, !tbaa !16
+  %9 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_addi(i32 0) #2
+  %10 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 4
+  store i32 %9, i32 addrspace(1)* %10, align 4, !tbaa !16
+  %11 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_muli(i32 0) #2
+  %12 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 5
+  store i32 %11, i32 addrspace(1)* %12, align 4, !tbaa !16
+  %13 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_mini(i32 0) #2
+  %14 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 6
+  store i32 %13, i32 addrspace(1)* %14, align 4, !tbaa !16
+  %15 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_maxi(i32 0) #2
+  %16 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 7
+  store i32 %15, i32 addrspace(1)* %16, align 4, !tbaa !16
+  %17 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_addi(i32 0) #2
+  %18 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 8
+  store i32 %17, i32 addrspace(1)* %18, align 4, !tbaa !16
+  %19 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_muli(i32 0) #2
+  %20 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 9
+  store i32 %19, i32 addrspace(1)* %20, align 4, !tbaa !16
+  %21 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_mini(i32 0) #2
+  %22 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 10
+  store i32 %21, i32 addrspace(1)* %22, align 4, !tbaa !16
+  %23 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_maxi(i32 0) #2
+  %24 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 11
+  store i32 %23, i32 addrspace(1)* %24, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_addi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_muli(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_mini(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_maxi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_addi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_muli(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_mini(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_maxi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_addi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_muli(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_mini(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_maxi(i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticUInt
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_addi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_muli(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_minj(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_maxj(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_addi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_muli(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_minj(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_maxj(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_addi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_muli(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_minj(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_maxj(i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticUInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !18 !kernel_arg_base_type !18 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_addj(i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_mulj(i32 0) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  %5 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_minj(i32 0) #2
+  %6 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %5, i32 addrspace(1)* %6, align 4, !tbaa !16
+  %7 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_maxj(i32 0) #2
+  %8 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 3
+  store i32 %7, i32 addrspace(1)* %8, align 4, !tbaa !16
+  %9 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_addj(i32 0) #2
+  %10 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 4
+  store i32 %9, i32 addrspace(1)* %10, align 4, !tbaa !16
+  %11 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_mulj(i32 0) #2
+  %12 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 5
+  store i32 %11, i32 addrspace(1)* %12, align 4, !tbaa !16
+  %13 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_minj(i32 0) #2
+  %14 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 6
+  store i32 %13, i32 addrspace(1)* %14, align 4, !tbaa !16
+  %15 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_maxj(i32 0) #2
+  %16 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 7
+  store i32 %15, i32 addrspace(1)* %16, align 4, !tbaa !16
+  %17 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_addj(i32 0) #2
+  %18 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 8
+  store i32 %17, i32 addrspace(1)* %18, align 4, !tbaa !16
+  %19 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_mulj(i32 0) #2
+  %20 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 9
+  store i32 %19, i32 addrspace(1)* %20, align 4, !tbaa !16
+  %21 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_minj(i32 0) #2
+  %22 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 10
+  store i32 %21, i32 addrspace(1)* %22, align 4, !tbaa !16
+  %23 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_maxj(i32 0) #2
+  %24 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 11
+  store i32 %23, i32 addrspace(1)* %24, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_addj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_mulj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_minj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_maxj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_addj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_mulj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_minj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_maxj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_addj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_mulj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_minj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_maxj(i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformSMin [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformSMax [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticLong
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_addl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_mull(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_minl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_maxl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_addl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_mull(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_minl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_maxl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_addl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_mull(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_minl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_maxl(i64 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticLong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !19 !kernel_arg_base_type !19 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_addl(i64 0) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_mull(i64 0) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  %5 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_minl(i64 0) #2
+  %6 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 2
+  store i64 %5, i64 addrspace(1)* %6, align 8, !tbaa !20
+  %7 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_maxl(i64 0) #2
+  %8 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 3
+  store i64 %7, i64 addrspace(1)* %8, align 8, !tbaa !20
+  %9 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_addl(i64 0) #2
+  %10 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 4
+  store i64 %9, i64 addrspace(1)* %10, align 8, !tbaa !20
+  %11 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_mull(i64 0) #2
+  %12 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 5
+  store i64 %11, i64 addrspace(1)* %12, align 8, !tbaa !20
+  %13 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_minl(i64 0) #2
+  %14 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 6
+  store i64 %13, i64 addrspace(1)* %14, align 8, !tbaa !20
+  %15 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_maxl(i64 0) #2
+  %16 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 7
+  store i64 %15, i64 addrspace(1)* %16, align 8, !tbaa !20
+  %17 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_addl(i64 0) #2
+  %18 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 8
+  store i64 %17, i64 addrspace(1)* %18, align 8, !tbaa !20
+  %19 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_mull(i64 0) #2
+  %20 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 9
+  store i64 %19, i64 addrspace(1)* %20, align 8, !tbaa !20
+  %21 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_minl(i64 0) #2
+  %22 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 10
+  store i64 %21, i64 addrspace(1)* %22, align 8, !tbaa !20
+  %23 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_maxl(i64 0) #2
+  %24 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 11
+  store i64 %23, i64 addrspace(1)* %24, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_addl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_mull(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_minl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_maxl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_addl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_mull(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_minl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_maxl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_addl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_mull(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_minl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_maxl(i64) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformIAdd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformIAdd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformIMul [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformUMin [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformUMax [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticULong
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_addl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_mull(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_minm(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_maxm(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_addl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_mull(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_minm(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_maxm(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_addl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_mull(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_minm(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_maxm(i64 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticULong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !22 !kernel_arg_base_type !22 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_addm(i64 0) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_mulm(i64 0) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  %5 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_minm(i64 0) #2
+  %6 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 2
+  store i64 %5, i64 addrspace(1)* %6, align 8, !tbaa !20
+  %7 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_maxm(i64 0) #2
+  %8 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 3
+  store i64 %7, i64 addrspace(1)* %8, align 8, !tbaa !20
+  %9 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_addm(i64 0) #2
+  %10 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 4
+  store i64 %9, i64 addrspace(1)* %10, align 8, !tbaa !20
+  %11 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_mulm(i64 0) #2
+  %12 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 5
+  store i64 %11, i64 addrspace(1)* %12, align 8, !tbaa !20
+  %13 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_minm(i64 0) #2
+  %14 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 6
+  store i64 %13, i64 addrspace(1)* %14, align 8, !tbaa !20
+  %15 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_maxm(i64 0) #2
+  %16 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 7
+  store i64 %15, i64 addrspace(1)* %16, align 8, !tbaa !20
+  %17 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_addm(i64 0) #2
+  %18 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 8
+  store i64 %17, i64 addrspace(1)* %18, align 8, !tbaa !20
+  %19 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_mulm(i64 0) #2
+  %20 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 9
+  store i64 %19, i64 addrspace(1)* %20, align 8, !tbaa !20
+  %21 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_minm(i64 0) #2
+  %22 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 10
+  store i64 %21, i64 addrspace(1)* %22, align 8, !tbaa !20
+  %23 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_maxm(i64 0) #2
+  %24 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 11
+  store i64 %23, i64 addrspace(1)* %24, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_addm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_mulm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_minm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_maxm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_addm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_mulm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_minm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_maxm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_addm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_mulm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_minm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_maxm(i64) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformFAdd [[float]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFMul [[float]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFMin [[float]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFMax [[float]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFAdd [[float]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFMul [[float]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFMin [[float]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFMax [[float]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFAdd [[float]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFMul [[float]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFMin [[float]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[float_0]]
+; CHECK-SPIRV: GroupNonUniformFMax [[float]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[float_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticFloat
+; CHECK-LLVM: call spir_func float @_Z32sub_group_non_uniform_reduce_addf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z32sub_group_non_uniform_reduce_mulf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z32sub_group_non_uniform_reduce_minf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z32sub_group_non_uniform_reduce_maxf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z40sub_group_non_uniform_scan_inclusive_addf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z40sub_group_non_uniform_scan_inclusive_mulf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z40sub_group_non_uniform_scan_inclusive_minf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z40sub_group_non_uniform_scan_inclusive_maxf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z40sub_group_non_uniform_scan_exclusive_addf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z40sub_group_non_uniform_scan_exclusive_mulf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z40sub_group_non_uniform_scan_exclusive_minf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func float @_Z40sub_group_non_uniform_scan_exclusive_maxf(float 0.000000e+00)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticFloat(float addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !23 !kernel_arg_base_type !23 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func float @_Z32sub_group_non_uniform_reduce_addf(float 0.000000e+00) #2
+  store float %2, float addrspace(1)* %0, align 4, !tbaa !24
+  %3 = tail call spir_func float @_Z32sub_group_non_uniform_reduce_mulf(float 0.000000e+00) #2
+  %4 = getelementptr inbounds float, float addrspace(1)* %0, i64 1
+  store float %3, float addrspace(1)* %4, align 4, !tbaa !24
+  %5 = tail call spir_func float @_Z32sub_group_non_uniform_reduce_minf(float 0.000000e+00) #2
+  %6 = getelementptr inbounds float, float addrspace(1)* %0, i64 2
+  store float %5, float addrspace(1)* %6, align 4, !tbaa !24
+  %7 = tail call spir_func float @_Z32sub_group_non_uniform_reduce_maxf(float 0.000000e+00) #2
+  %8 = getelementptr inbounds float, float addrspace(1)* %0, i64 3
+  store float %7, float addrspace(1)* %8, align 4, !tbaa !24
+  %9 = tail call spir_func float @_Z40sub_group_non_uniform_scan_inclusive_addf(float 0.000000e+00) #2
+  %10 = getelementptr inbounds float, float addrspace(1)* %0, i64 4
+  store float %9, float addrspace(1)* %10, align 4, !tbaa !24
+  %11 = tail call spir_func float @_Z40sub_group_non_uniform_scan_inclusive_mulf(float 0.000000e+00) #2
+  %12 = getelementptr inbounds float, float addrspace(1)* %0, i64 5
+  store float %11, float addrspace(1)* %12, align 4, !tbaa !24
+  %13 = tail call spir_func float @_Z40sub_group_non_uniform_scan_inclusive_minf(float 0.000000e+00) #2
+  %14 = getelementptr inbounds float, float addrspace(1)* %0, i64 6
+  store float %13, float addrspace(1)* %14, align 4, !tbaa !24
+  %15 = tail call spir_func float @_Z40sub_group_non_uniform_scan_inclusive_maxf(float 0.000000e+00) #2
+  %16 = getelementptr inbounds float, float addrspace(1)* %0, i64 7
+  store float %15, float addrspace(1)* %16, align 4, !tbaa !24
+  %17 = tail call spir_func float @_Z40sub_group_non_uniform_scan_exclusive_addf(float 0.000000e+00) #2
+  %18 = getelementptr inbounds float, float addrspace(1)* %0, i64 8
+  store float %17, float addrspace(1)* %18, align 4, !tbaa !24
+  %19 = tail call spir_func float @_Z40sub_group_non_uniform_scan_exclusive_mulf(float 0.000000e+00) #2
+  %20 = getelementptr inbounds float, float addrspace(1)* %0, i64 9
+  store float %19, float addrspace(1)* %20, align 4, !tbaa !24
+  %21 = tail call spir_func float @_Z40sub_group_non_uniform_scan_exclusive_minf(float 0.000000e+00) #2
+  %22 = getelementptr inbounds float, float addrspace(1)* %0, i64 10
+  store float %21, float addrspace(1)* %22, align 4, !tbaa !24
+  %23 = tail call spir_func float @_Z40sub_group_non_uniform_scan_exclusive_maxf(float 0.000000e+00) #2
+  %24 = getelementptr inbounds float, float addrspace(1)* %0, i64 11
+  store float %23, float addrspace(1)* %24, align 4, !tbaa !24
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z32sub_group_non_uniform_reduce_addf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z32sub_group_non_uniform_reduce_mulf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z32sub_group_non_uniform_reduce_minf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z32sub_group_non_uniform_reduce_maxf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z40sub_group_non_uniform_scan_inclusive_addf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z40sub_group_non_uniform_scan_inclusive_mulf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z40sub_group_non_uniform_scan_inclusive_minf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z40sub_group_non_uniform_scan_inclusive_maxf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z40sub_group_non_uniform_scan_exclusive_addf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z40sub_group_non_uniform_scan_exclusive_mulf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z40sub_group_non_uniform_scan_exclusive_minf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z40sub_group_non_uniform_scan_exclusive_maxf(float) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformFAdd [[half]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFMul [[half]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFMin [[half]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFMax [[half]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFAdd [[half]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFMul [[half]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFMin [[half]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFMax [[half]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFAdd [[half]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFMul [[half]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFMin [[half]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[half_0]]
+; CHECK-SPIRV: GroupNonUniformFMax [[half]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[half_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticHalf
+; CHECK-LLVM: call spir_func half @_Z32sub_group_non_uniform_reduce_addDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z32sub_group_non_uniform_reduce_mulDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z32sub_group_non_uniform_reduce_minDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z32sub_group_non_uniform_reduce_maxDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z40sub_group_non_uniform_scan_inclusive_addDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z40sub_group_non_uniform_scan_inclusive_mulDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z40sub_group_non_uniform_scan_inclusive_minDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z40sub_group_non_uniform_scan_inclusive_maxDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z40sub_group_non_uniform_scan_exclusive_addDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z40sub_group_non_uniform_scan_exclusive_mulDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z40sub_group_non_uniform_scan_exclusive_minDh(half 0xH0000)
+; CHECK-LLVM: call spir_func half @_Z40sub_group_non_uniform_scan_exclusive_maxDh(half 0xH0000)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticHalf(half addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !26 !kernel_arg_base_type !26 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func half @_Z32sub_group_non_uniform_reduce_addDh(half 0xH0000) #2
+  store half %2, half addrspace(1)* %0, align 2, !tbaa !27
+  %3 = tail call spir_func half @_Z32sub_group_non_uniform_reduce_mulDh(half 0xH0000) #2
+  %4 = getelementptr inbounds half, half addrspace(1)* %0, i64 1
+  store half %3, half addrspace(1)* %4, align 2, !tbaa !27
+  %5 = tail call spir_func half @_Z32sub_group_non_uniform_reduce_minDh(half 0xH0000) #2
+  %6 = getelementptr inbounds half, half addrspace(1)* %0, i64 2
+  store half %5, half addrspace(1)* %6, align 2, !tbaa !27
+  %7 = tail call spir_func half @_Z32sub_group_non_uniform_reduce_maxDh(half 0xH0000) #2
+  %8 = getelementptr inbounds half, half addrspace(1)* %0, i64 3
+  store half %7, half addrspace(1)* %8, align 2, !tbaa !27
+  %9 = tail call spir_func half @_Z40sub_group_non_uniform_scan_inclusive_addDh(half 0xH0000) #2
+  %10 = getelementptr inbounds half, half addrspace(1)* %0, i64 4
+  store half %9, half addrspace(1)* %10, align 2, !tbaa !27
+  %11 = tail call spir_func half @_Z40sub_group_non_uniform_scan_inclusive_mulDh(half 0xH0000) #2
+  %12 = getelementptr inbounds half, half addrspace(1)* %0, i64 5
+  store half %11, half addrspace(1)* %12, align 2, !tbaa !27
+  %13 = tail call spir_func half @_Z40sub_group_non_uniform_scan_inclusive_minDh(half 0xH0000) #2
+  %14 = getelementptr inbounds half, half addrspace(1)* %0, i64 6
+  store half %13, half addrspace(1)* %14, align 2, !tbaa !27
+  %15 = tail call spir_func half @_Z40sub_group_non_uniform_scan_inclusive_maxDh(half 0xH0000) #2
+  %16 = getelementptr inbounds half, half addrspace(1)* %0, i64 7
+  store half %15, half addrspace(1)* %16, align 2, !tbaa !27
+  %17 = tail call spir_func half @_Z40sub_group_non_uniform_scan_exclusive_addDh(half 0xH0000) #2
+  %18 = getelementptr inbounds half, half addrspace(1)* %0, i64 8
+  store half %17, half addrspace(1)* %18, align 2, !tbaa !27
+  %19 = tail call spir_func half @_Z40sub_group_non_uniform_scan_exclusive_mulDh(half 0xH0000) #2
+  %20 = getelementptr inbounds half, half addrspace(1)* %0, i64 9
+  store half %19, half addrspace(1)* %20, align 2, !tbaa !27
+  %21 = tail call spir_func half @_Z40sub_group_non_uniform_scan_exclusive_minDh(half 0xH0000) #2
+  %22 = getelementptr inbounds half, half addrspace(1)* %0, i64 10
+  store half %21, half addrspace(1)* %22, align 2, !tbaa !27
+  %23 = tail call spir_func half @_Z40sub_group_non_uniform_scan_exclusive_maxDh(half 0xH0000) #2
+  %24 = getelementptr inbounds half, half addrspace(1)* %0, i64 11
+  store half %23, half addrspace(1)* %24, align 2, !tbaa !27
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z32sub_group_non_uniform_reduce_addDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z32sub_group_non_uniform_reduce_mulDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z32sub_group_non_uniform_reduce_minDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z32sub_group_non_uniform_reduce_maxDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z40sub_group_non_uniform_scan_inclusive_addDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z40sub_group_non_uniform_scan_inclusive_mulDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z40sub_group_non_uniform_scan_inclusive_minDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z40sub_group_non_uniform_scan_inclusive_maxDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z40sub_group_non_uniform_scan_exclusive_addDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z40sub_group_non_uniform_scan_exclusive_mulDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z40sub_group_non_uniform_scan_exclusive_minDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z40sub_group_non_uniform_scan_exclusive_maxDh(half) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformFAdd [[double]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFMul [[double]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFMin [[double]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFMax [[double]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFAdd [[double]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFMul [[double]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFMin [[double]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFMax [[double]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFAdd [[double]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFMul [[double]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFMin [[double]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[double_0]]
+; CHECK-SPIRV: GroupNonUniformFMax [[double]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[double_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformArithmeticDouble
+; CHECK-LLVM: call spir_func double @_Z32sub_group_non_uniform_reduce_addd(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z32sub_group_non_uniform_reduce_muld(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z32sub_group_non_uniform_reduce_mind(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z32sub_group_non_uniform_reduce_maxd(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z40sub_group_non_uniform_scan_inclusive_addd(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z40sub_group_non_uniform_scan_inclusive_muld(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z40sub_group_non_uniform_scan_inclusive_mind(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z40sub_group_non_uniform_scan_inclusive_maxd(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z40sub_group_non_uniform_scan_exclusive_addd(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z40sub_group_non_uniform_scan_exclusive_muld(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z40sub_group_non_uniform_scan_exclusive_mind(double 0.000000e+00)
+; CHECK-LLVM: call spir_func double @_Z40sub_group_non_uniform_scan_exclusive_maxd(double 0.000000e+00)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformArithmeticDouble(double addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !29 !kernel_arg_base_type !29 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func double @_Z32sub_group_non_uniform_reduce_addd(double 0.000000e+00) #2
+  store double %2, double addrspace(1)* %0, align 8, !tbaa !30
+  %3 = tail call spir_func double @_Z32sub_group_non_uniform_reduce_muld(double 0.000000e+00) #2
+  %4 = getelementptr inbounds double, double addrspace(1)* %0, i64 1
+  store double %3, double addrspace(1)* %4, align 8, !tbaa !30
+  %5 = tail call spir_func double @_Z32sub_group_non_uniform_reduce_mind(double 0.000000e+00) #2
+  %6 = getelementptr inbounds double, double addrspace(1)* %0, i64 2
+  store double %5, double addrspace(1)* %6, align 8, !tbaa !30
+  %7 = tail call spir_func double @_Z32sub_group_non_uniform_reduce_maxd(double 0.000000e+00) #2
+  %8 = getelementptr inbounds double, double addrspace(1)* %0, i64 3
+  store double %7, double addrspace(1)* %8, align 8, !tbaa !30
+  %9 = tail call spir_func double @_Z40sub_group_non_uniform_scan_inclusive_addd(double 0.000000e+00) #2
+  %10 = getelementptr inbounds double, double addrspace(1)* %0, i64 4
+  store double %9, double addrspace(1)* %10, align 8, !tbaa !30
+  %11 = tail call spir_func double @_Z40sub_group_non_uniform_scan_inclusive_muld(double 0.000000e+00) #2
+  %12 = getelementptr inbounds double, double addrspace(1)* %0, i64 5
+  store double %11, double addrspace(1)* %12, align 8, !tbaa !30
+  %13 = tail call spir_func double @_Z40sub_group_non_uniform_scan_inclusive_mind(double 0.000000e+00) #2
+  %14 = getelementptr inbounds double, double addrspace(1)* %0, i64 6
+  store double %13, double addrspace(1)* %14, align 8, !tbaa !30
+  %15 = tail call spir_func double @_Z40sub_group_non_uniform_scan_inclusive_maxd(double 0.000000e+00) #2
+  %16 = getelementptr inbounds double, double addrspace(1)* %0, i64 7
+  store double %15, double addrspace(1)* %16, align 8, !tbaa !30
+  %17 = tail call spir_func double @_Z40sub_group_non_uniform_scan_exclusive_addd(double 0.000000e+00) #2
+  %18 = getelementptr inbounds double, double addrspace(1)* %0, i64 8
+  store double %17, double addrspace(1)* %18, align 8, !tbaa !30
+  %19 = tail call spir_func double @_Z40sub_group_non_uniform_scan_exclusive_muld(double 0.000000e+00) #2
+  %20 = getelementptr inbounds double, double addrspace(1)* %0, i64 9
+  store double %19, double addrspace(1)* %20, align 8, !tbaa !30
+  %21 = tail call spir_func double @_Z40sub_group_non_uniform_scan_exclusive_mind(double 0.000000e+00) #2
+  %22 = getelementptr inbounds double, double addrspace(1)* %0, i64 10
+  store double %21, double addrspace(1)* %22, align 8, !tbaa !30
+  %23 = tail call spir_func double @_Z40sub_group_non_uniform_scan_exclusive_maxd(double 0.000000e+00) #2
+  %24 = getelementptr inbounds double, double addrspace(1)* %0, i64 11
+  store double %23, double addrspace(1)* %24, align 8, !tbaa !30
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z32sub_group_non_uniform_reduce_addd(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z32sub_group_non_uniform_reduce_muld(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z32sub_group_non_uniform_reduce_mind(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z32sub_group_non_uniform_reduce_maxd(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z40sub_group_non_uniform_scan_inclusive_addd(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z40sub_group_non_uniform_scan_inclusive_muld(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z40sub_group_non_uniform_scan_inclusive_mind(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z40sub_group_non_uniform_scan_inclusive_maxd(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z40sub_group_non_uniform_scan_exclusive_addd(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z40sub_group_non_uniform_scan_exclusive_muld(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z40sub_group_non_uniform_scan_exclusive_mind(double) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z40sub_group_non_uniform_scan_exclusive_maxd(double) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBitwiseChar
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_andc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z31sub_group_non_uniform_reduce_orc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_xorc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_andc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z39sub_group_non_uniform_scan_inclusive_orc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_xorc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_andc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z39sub_group_non_uniform_scan_exclusive_orc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_xorc(i8 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBitwiseChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i8 @_Z32sub_group_non_uniform_reduce_andc(i8 signext 0) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func signext i8 @_Z31sub_group_non_uniform_reduce_orc(i8 signext 0) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  %5 = tail call spir_func signext i8 @_Z32sub_group_non_uniform_reduce_xorc(i8 signext 0) #2
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2
+  store i8 %5, i8 addrspace(1)* %6, align 1, !tbaa !7
+  %7 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_andc(i8 signext 0) #2
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 3
+  store i8 %7, i8 addrspace(1)* %8, align 1, !tbaa !7
+  %9 = tail call spir_func signext i8 @_Z39sub_group_non_uniform_scan_inclusive_orc(i8 signext 0) #2
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 4
+  store i8 %9, i8 addrspace(1)* %10, align 1, !tbaa !7
+  %11 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_xorc(i8 signext 0) #2
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 5
+  store i8 %11, i8 addrspace(1)* %12, align 1, !tbaa !7
+  %13 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_andc(i8 signext 0) #2
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 6
+  store i8 %13, i8 addrspace(1)* %14, align 1, !tbaa !7
+  %15 = tail call spir_func signext i8 @_Z39sub_group_non_uniform_scan_exclusive_orc(i8 signext 0) #2
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 7
+  store i8 %15, i8 addrspace(1)* %16, align 1, !tbaa !7
+  %17 = tail call spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_xorc(i8 signext 0) #2
+  %18 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 8
+  store i8 %17, i8 addrspace(1)* %18, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z32sub_group_non_uniform_reduce_andc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z31sub_group_non_uniform_reduce_orc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z32sub_group_non_uniform_reduce_xorc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_andc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z39sub_group_non_uniform_scan_inclusive_orc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_inclusive_xorc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_andc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z39sub_group_non_uniform_scan_exclusive_orc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_xorc(i8 signext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[char]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[char]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[char]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[char_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBitwiseUChar
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_andc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z31sub_group_non_uniform_reduce_orc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z32sub_group_non_uniform_reduce_xorc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_andc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z39sub_group_non_uniform_scan_inclusive_orc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_inclusive_xorc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_andc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z39sub_group_non_uniform_scan_exclusive_orc(i8 0)
+; CHECK-LLVM: call spir_func i8 @_Z40sub_group_non_uniform_scan_exclusive_xorc(i8 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBitwiseUChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !10 !kernel_arg_base_type !10 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_andh(i8 zeroext 0) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func zeroext i8 @_Z31sub_group_non_uniform_reduce_orh(i8 zeroext 0) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  %5 = tail call spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_xorh(i8 zeroext 0) #2
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2
+  store i8 %5, i8 addrspace(1)* %6, align 1, !tbaa !7
+  %7 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_andh(i8 zeroext 0) #2
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 3
+  store i8 %7, i8 addrspace(1)* %8, align 1, !tbaa !7
+  %9 = tail call spir_func zeroext i8 @_Z39sub_group_non_uniform_scan_inclusive_orh(i8 zeroext 0) #2
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 4
+  store i8 %9, i8 addrspace(1)* %10, align 1, !tbaa !7
+  %11 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_xorh(i8 zeroext 0) #2
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 5
+  store i8 %11, i8 addrspace(1)* %12, align 1, !tbaa !7
+  %13 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_andh(i8 zeroext 0) #2
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 6
+  store i8 %13, i8 addrspace(1)* %14, align 1, !tbaa !7
+  %15 = tail call spir_func zeroext i8 @_Z39sub_group_non_uniform_scan_exclusive_orh(i8 zeroext 0) #2
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 7
+  store i8 %15, i8 addrspace(1)* %16, align 1, !tbaa !7
+  %17 = tail call spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_xorh(i8 zeroext 0) #2
+  %18 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 8
+  store i8 %17, i8 addrspace(1)* %18, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_andh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z31sub_group_non_uniform_reduce_orh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z32sub_group_non_uniform_reduce_xorh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_andh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z39sub_group_non_uniform_scan_inclusive_orh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_inclusive_xorh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_andh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z39sub_group_non_uniform_scan_exclusive_orh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_xorh(i8 zeroext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBitwiseShort
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_ands(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z31sub_group_non_uniform_reduce_ors(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_xors(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_ands(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z39sub_group_non_uniform_scan_inclusive_ors(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_xors(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_ands(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z39sub_group_non_uniform_scan_exclusive_ors(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_xors(i16 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBitwiseShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !11 !kernel_arg_base_type !11 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i16 @_Z32sub_group_non_uniform_reduce_ands(i16 signext 0) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func signext i16 @_Z31sub_group_non_uniform_reduce_ors(i16 signext 0) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  %5 = tail call spir_func signext i16 @_Z32sub_group_non_uniform_reduce_xors(i16 signext 0) #2
+  %6 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 2
+  store i16 %5, i16 addrspace(1)* %6, align 2, !tbaa !12
+  %7 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_ands(i16 signext 0) #2
+  %8 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 3
+  store i16 %7, i16 addrspace(1)* %8, align 2, !tbaa !12
+  %9 = tail call spir_func signext i16 @_Z39sub_group_non_uniform_scan_inclusive_ors(i16 signext 0) #2
+  %10 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 4
+  store i16 %9, i16 addrspace(1)* %10, align 2, !tbaa !12
+  %11 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_xors(i16 signext 0) #2
+  %12 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 5
+  store i16 %11, i16 addrspace(1)* %12, align 2, !tbaa !12
+  %13 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_ands(i16 signext 0) #2
+  %14 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 6
+  store i16 %13, i16 addrspace(1)* %14, align 2, !tbaa !12
+  %15 = tail call spir_func signext i16 @_Z39sub_group_non_uniform_scan_exclusive_ors(i16 signext 0) #2
+  %16 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 7
+  store i16 %15, i16 addrspace(1)* %16, align 2, !tbaa !12
+  %17 = tail call spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_xors(i16 signext 0) #2
+  %18 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 8
+  store i16 %17, i16 addrspace(1)* %18, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z32sub_group_non_uniform_reduce_ands(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z31sub_group_non_uniform_reduce_ors(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z32sub_group_non_uniform_reduce_xors(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_ands(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z39sub_group_non_uniform_scan_inclusive_ors(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_inclusive_xors(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_ands(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z39sub_group_non_uniform_scan_exclusive_ors(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_xors(i16 signext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[short]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[short]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[short]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[short_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBitwiseUShort
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_ands(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z31sub_group_non_uniform_reduce_ors(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z32sub_group_non_uniform_reduce_xors(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_ands(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z39sub_group_non_uniform_scan_inclusive_ors(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_inclusive_xors(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_ands(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z39sub_group_non_uniform_scan_exclusive_ors(i16 0)
+; CHECK-LLVM: call spir_func i16 @_Z40sub_group_non_uniform_scan_exclusive_xors(i16 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBitwiseUShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !14 !kernel_arg_base_type !14 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_andt(i16 zeroext 0) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func zeroext i16 @_Z31sub_group_non_uniform_reduce_ort(i16 zeroext 0) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  %5 = tail call spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_xort(i16 zeroext 0) #2
+  %6 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 2
+  store i16 %5, i16 addrspace(1)* %6, align 2, !tbaa !12
+  %7 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_andt(i16 zeroext 0) #2
+  %8 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 3
+  store i16 %7, i16 addrspace(1)* %8, align 2, !tbaa !12
+  %9 = tail call spir_func zeroext i16 @_Z39sub_group_non_uniform_scan_inclusive_ort(i16 zeroext 0) #2
+  %10 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 4
+  store i16 %9, i16 addrspace(1)* %10, align 2, !tbaa !12
+  %11 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_xort(i16 zeroext 0) #2
+  %12 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 5
+  store i16 %11, i16 addrspace(1)* %12, align 2, !tbaa !12
+  %13 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_andt(i16 zeroext 0) #2
+  %14 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 6
+  store i16 %13, i16 addrspace(1)* %14, align 2, !tbaa !12
+  %15 = tail call spir_func zeroext i16 @_Z39sub_group_non_uniform_scan_exclusive_ort(i16 zeroext 0) #2
+  %16 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 7
+  store i16 %15, i16 addrspace(1)* %16, align 2, !tbaa !12
+  %17 = tail call spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_xort(i16 zeroext 0) #2
+  %18 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 8
+  store i16 %17, i16 addrspace(1)* %18, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_andt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z31sub_group_non_uniform_reduce_ort(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z32sub_group_non_uniform_reduce_xort(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_andt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z39sub_group_non_uniform_scan_inclusive_ort(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_inclusive_xort(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_andt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z39sub_group_non_uniform_scan_exclusive_ort(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_xort(i16 zeroext) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBitwiseInt
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_andi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_reduce_ori(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_xori(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_andi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z39sub_group_non_uniform_scan_inclusive_ori(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_xori(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_andi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z39sub_group_non_uniform_scan_exclusive_ori(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_xori(i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBitwiseInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !15 !kernel_arg_base_type !15 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_andi(i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z31sub_group_non_uniform_reduce_ori(i32 0) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  %5 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_xori(i32 0) #2
+  %6 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %5, i32 addrspace(1)* %6, align 4, !tbaa !16
+  %7 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_andi(i32 0) #2
+  %8 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 3
+  store i32 %7, i32 addrspace(1)* %8, align 4, !tbaa !16
+  %9 = tail call spir_func i32 @_Z39sub_group_non_uniform_scan_inclusive_ori(i32 0) #2
+  %10 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 4
+  store i32 %9, i32 addrspace(1)* %10, align 4, !tbaa !16
+  %11 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_xori(i32 0) #2
+  %12 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 5
+  store i32 %11, i32 addrspace(1)* %12, align 4, !tbaa !16
+  %13 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_andi(i32 0) #2
+  %14 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 6
+  store i32 %13, i32 addrspace(1)* %14, align 4, !tbaa !16
+  %15 = tail call spir_func i32 @_Z39sub_group_non_uniform_scan_exclusive_ori(i32 0) #2
+  %16 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 7
+  store i32 %15, i32 addrspace(1)* %16, align 4, !tbaa !16
+  %17 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_xori(i32 0) #2
+  %18 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 8
+  store i32 %17, i32 addrspace(1)* %18, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_andi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_reduce_ori(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_xori(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_andi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z39sub_group_non_uniform_scan_inclusive_ori(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_xori(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_andi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z39sub_group_non_uniform_scan_exclusive_ori(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_xori(i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[int]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[int]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[int]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBitwiseUInt
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_andi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_reduce_ori(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z32sub_group_non_uniform_reduce_xori(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_andi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z39sub_group_non_uniform_scan_inclusive_ori(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_xori(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_andi(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z39sub_group_non_uniform_scan_exclusive_ori(i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_xori(i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBitwiseUInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !18 !kernel_arg_base_type !18 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_andj(i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z31sub_group_non_uniform_reduce_orj(i32 0) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  %5 = tail call spir_func i32 @_Z32sub_group_non_uniform_reduce_xorj(i32 0) #2
+  %6 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %5, i32 addrspace(1)* %6, align 4, !tbaa !16
+  %7 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_andj(i32 0) #2
+  %8 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 3
+  store i32 %7, i32 addrspace(1)* %8, align 4, !tbaa !16
+  %9 = tail call spir_func i32 @_Z39sub_group_non_uniform_scan_inclusive_orj(i32 0) #2
+  %10 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 4
+  store i32 %9, i32 addrspace(1)* %10, align 4, !tbaa !16
+  %11 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_xorj(i32 0) #2
+  %12 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 5
+  store i32 %11, i32 addrspace(1)* %12, align 4, !tbaa !16
+  %13 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_andj(i32 0) #2
+  %14 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 6
+  store i32 %13, i32 addrspace(1)* %14, align 4, !tbaa !16
+  %15 = tail call spir_func i32 @_Z39sub_group_non_uniform_scan_exclusive_orj(i32 0) #2
+  %16 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 7
+  store i32 %15, i32 addrspace(1)* %16, align 4, !tbaa !16
+  %17 = tail call spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_xorj(i32 0) #2
+  %18 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 8
+  store i32 %17, i32 addrspace(1)* %18, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_andj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_reduce_orj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z32sub_group_non_uniform_reduce_xorj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_andj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z39sub_group_non_uniform_scan_inclusive_orj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_inclusive_xorj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_andj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z39sub_group_non_uniform_scan_exclusive_orj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_xorj(i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBitwiseLong
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_andl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z31sub_group_non_uniform_reduce_orl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_xorl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_andl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z39sub_group_non_uniform_scan_inclusive_orl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_xorl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_andl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z39sub_group_non_uniform_scan_exclusive_orl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_xorl(i64 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBitwiseLong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !19 !kernel_arg_base_type !19 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_andl(i64 0) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z31sub_group_non_uniform_reduce_orl(i64 0) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  %5 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_xorl(i64 0) #2
+  %6 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 2
+  store i64 %5, i64 addrspace(1)* %6, align 8, !tbaa !20
+  %7 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_andl(i64 0) #2
+  %8 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 3
+  store i64 %7, i64 addrspace(1)* %8, align 8, !tbaa !20
+  %9 = tail call spir_func i64 @_Z39sub_group_non_uniform_scan_inclusive_orl(i64 0) #2
+  %10 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 4
+  store i64 %9, i64 addrspace(1)* %10, align 8, !tbaa !20
+  %11 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_xorl(i64 0) #2
+  %12 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 5
+  store i64 %11, i64 addrspace(1)* %12, align 8, !tbaa !20
+  %13 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_andl(i64 0) #2
+  %14 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 6
+  store i64 %13, i64 addrspace(1)* %14, align 8, !tbaa !20
+  %15 = tail call spir_func i64 @_Z39sub_group_non_uniform_scan_exclusive_orl(i64 0) #2
+  %16 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 7
+  store i64 %15, i64 addrspace(1)* %16, align 8, !tbaa !20
+  %17 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_xorl(i64 0) #2
+  %18 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 8
+  store i64 %17, i64 addrspace(1)* %18, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_andl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z31sub_group_non_uniform_reduce_orl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_xorl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_andl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z39sub_group_non_uniform_scan_inclusive_orl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_xorl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_andl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z39sub_group_non_uniform_scan_exclusive_orl(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_xorl(i64) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[long]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[long]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseAnd [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseOr  [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: GroupNonUniformBitwiseXor [[long]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[long_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformBitwiseULong
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_andl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z31sub_group_non_uniform_reduce_orl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z32sub_group_non_uniform_reduce_xorl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_andl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z39sub_group_non_uniform_scan_inclusive_orl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_xorl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_andl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z39sub_group_non_uniform_scan_exclusive_orl(i64 0)
+; CHECK-LLVM: call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_xorl(i64 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformBitwiseULong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !22 !kernel_arg_base_type !22 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_andm(i64 0) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z31sub_group_non_uniform_reduce_orm(i64 0) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  %5 = tail call spir_func i64 @_Z32sub_group_non_uniform_reduce_xorm(i64 0) #2
+  %6 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 2
+  store i64 %5, i64 addrspace(1)* %6, align 8, !tbaa !20
+  %7 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_andm(i64 0) #2
+  %8 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 3
+  store i64 %7, i64 addrspace(1)* %8, align 8, !tbaa !20
+  %9 = tail call spir_func i64 @_Z39sub_group_non_uniform_scan_inclusive_orm(i64 0) #2
+  %10 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 4
+  store i64 %9, i64 addrspace(1)* %10, align 8, !tbaa !20
+  %11 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_xorm(i64 0) #2
+  %12 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 5
+  store i64 %11, i64 addrspace(1)* %12, align 8, !tbaa !20
+  %13 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_andm(i64 0) #2
+  %14 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 6
+  store i64 %13, i64 addrspace(1)* %14, align 8, !tbaa !20
+  %15 = tail call spir_func i64 @_Z39sub_group_non_uniform_scan_exclusive_orm(i64 0) #2
+  %16 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 7
+  store i64 %15, i64 addrspace(1)* %16, align 8, !tbaa !20
+  %17 = tail call spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_xorm(i64 0) #2
+  %18 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 8
+  store i64 %17, i64 addrspace(1)* %18, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_andm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z31sub_group_non_uniform_reduce_orm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z32sub_group_non_uniform_reduce_xorm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_andm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z39sub_group_non_uniform_scan_inclusive_orm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_inclusive_xorm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_andm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z39sub_group_non_uniform_scan_exclusive_orm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_xorm(i64) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformLogicalAnd [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[false]]
+; CHECK-SPIRV: GroupNonUniformLogicalOr  [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[false]]
+; CHECK-SPIRV: GroupNonUniformLogicalXor [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 0 [[false]]
+; CHECK-SPIRV: GroupNonUniformLogicalAnd [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[false]]
+; CHECK-SPIRV: GroupNonUniformLogicalOr  [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[false]]
+; CHECK-SPIRV: GroupNonUniformLogicalXor [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 1 [[false]]
+; CHECK-SPIRV: GroupNonUniformLogicalAnd [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[false]]
+; CHECK-SPIRV: GroupNonUniformLogicalOr  [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[false]]
+; CHECK-SPIRV: GroupNonUniformLogicalXor [[bool]] {{[0-9]+}} [[ScopeSubgroup]] 2 [[false]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testNonUniformLogical
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_reduce_logical_andi(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z39sub_group_non_uniform_reduce_logical_ori(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z40sub_group_non_uniform_reduce_logical_xori(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z48sub_group_non_uniform_scan_inclusive_logical_andi(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z47sub_group_non_uniform_scan_inclusive_logical_ori(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z48sub_group_non_uniform_scan_inclusive_logical_xori(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z48sub_group_non_uniform_scan_exclusive_logical_andi(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z47sub_group_non_uniform_scan_exclusive_logical_ori(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z48sub_group_non_uniform_scan_exclusive_logical_xori(i32 {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testNonUniformLogical(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !15 !kernel_arg_base_type !15 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z40sub_group_non_uniform_reduce_logical_andi(i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z39sub_group_non_uniform_reduce_logical_ori(i32 0) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  %5 = tail call spir_func i32 @_Z40sub_group_non_uniform_reduce_logical_xori(i32 0) #2
+  %6 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 2
+  store i32 %5, i32 addrspace(1)* %6, align 4, !tbaa !16
+  %7 = tail call spir_func i32 @_Z48sub_group_non_uniform_scan_inclusive_logical_andi(i32 0) #2
+  %8 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 3
+  store i32 %7, i32 addrspace(1)* %8, align 4, !tbaa !16
+  %9 = tail call spir_func i32 @_Z47sub_group_non_uniform_scan_inclusive_logical_ori(i32 0) #2
+  %10 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 4
+  store i32 %9, i32 addrspace(1)* %10, align 4, !tbaa !16
+  %11 = tail call spir_func i32 @_Z48sub_group_non_uniform_scan_inclusive_logical_xori(i32 0) #2
+  %12 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 5
+  store i32 %11, i32 addrspace(1)* %12, align 4, !tbaa !16
+  %13 = tail call spir_func i32 @_Z48sub_group_non_uniform_scan_exclusive_logical_andi(i32 0) #2
+  %14 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 6
+  store i32 %13, i32 addrspace(1)* %14, align 4, !tbaa !16
+  %15 = tail call spir_func i32 @_Z47sub_group_non_uniform_scan_exclusive_logical_ori(i32 0) #2
+  %16 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 7
+  store i32 %15, i32 addrspace(1)* %16, align 4, !tbaa !16
+  %17 = tail call spir_func i32 @_Z48sub_group_non_uniform_scan_exclusive_logical_xori(i32 0) #2
+  %18 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 8
+  store i32 %17, i32 addrspace(1)* %18, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_reduce_logical_andi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z39sub_group_non_uniform_reduce_logical_ori(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z40sub_group_non_uniform_reduce_logical_xori(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z48sub_group_non_uniform_scan_inclusive_logical_andi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z47sub_group_non_uniform_scan_inclusive_logical_ori(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z48sub_group_non_uniform_scan_inclusive_logical_xori(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z48sub_group_non_uniform_scan_exclusive_logical_andi(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z47sub_group_non_uniform_scan_exclusive_logical_ori(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z48sub_group_non_uniform_scan_exclusive_logical_xori(i32) local_unnamed_addr #1
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.1 (https://github.com/llvm/llvm-project.git cb6d58d1dcf36a29ae5dd24ff891d6552f00bac7)"}
+!3 = !{i32 1}
+!4 = !{!"none"}
+!5 = !{!"char*"}
+!6 = !{!""}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !{!"uchar*"}
+!11 = !{!"short*"}
+!12 = !{!13, !13, i64 0}
+!13 = !{!"short", !8, i64 0}
+!14 = !{!"ushort*"}
+!15 = !{!"int*"}
+!16 = !{!17, !17, i64 0}
+!17 = !{!"int", !8, i64 0}
+!18 = !{!"uint*"}
+!19 = !{!"long*"}
+!20 = !{!21, !21, i64 0}
+!21 = !{!"long", !8, i64 0}
+!22 = !{!"ulong*"}
+!23 = !{!"float*"}
+!24 = !{!25, !25, i64 0}
+!25 = !{!"float", !8, i64 0}
+!26 = !{!"half*"}
+!27 = !{!28, !28, i64 0}
+!28 = !{!"half", !8, i64 0}
+!29 = !{!"double*"}
+!30 = !{!31, !31, i64 0}
+!31 = !{!"double", !8, i64 0}

--- a/test/transcoding/sub_group_non_uniform_vote.ll
+++ b/test/transcoding/sub_group_non_uniform_vote.ll
@@ -1,0 +1,254 @@
+;; #pragma OPENCL EXTENSION cl_khr_subgroup_non_uniform_vote : enable
+;; 
+;; kernel void testSubGroupElect(global int* dst){
+;; 	dst[0] = sub_group_elect();
+;; }
+;; 
+;; kernel void testSubGroupNonUniformAll(global int* dst){
+;; 	dst[0] = sub_group_non_uniform_all(0); 
+;; }
+;; 
+;; kernel void testSubGroupNonUniformAny(global int* dst){
+;; 	dst[0] = sub_group_non_uniform_any(0);
+;; }
+;; 
+;; #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+;; kernel void testSubGroupNonUniformAllEqual(global int* dst){
+;;     {
+;;         char v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;;     {
+;;         uchar v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;;     {
+;;         short v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;;     {
+;;         ushort v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;;     {
+;;         int v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;;     {
+;;         uint v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;;     {
+;;         long v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;;     {
+;;         ulong v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;;     {
+;;         float v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;;     {
+;;         half v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;;     {
+;;         double v = 0;
+;;         dst[0] = sub_group_non_uniform_all_equal( v );
+;;     }
+;; }
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; Change DISABLED to RUN once SPIRV->LLVM translation is implemented
+; DISABLED: llvm-spirv -r %t.spv -o %t.rev.bc
+; DISABLED: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; ModuleID = 'sub_group_non_uniform_vote.cl'
+source_filename = "sub_group_non_uniform_vote.cl"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+; CHECK-SPIRV-DAG: TypeBool  [[bool:[0-9]+]]
+; CHECK-SPIRV-DAG: TypeInt   [[char:[0-9]+]]   8  0
+; CHECK-SPIRV-DAG: TypeInt   [[short:[0-9]+]]  16 0
+; CHECK-SPIRV-DAG: TypeInt   [[int:[0-9]+]]    32 0
+; CHECK-SPIRV-DAG: TypeInt   [[long:[0-9]+]]   64 0
+; CHECK-SPIRV-DAG: TypeFloat [[half:[0-9]+]]   16
+; CHECK-SPIRV-DAG: TypeFloat [[float:[0-9]+]]  32
+; CHECK-SPIRV-DAG: TypeFloat [[double:[0-9]+]] 64
+
+; CHECK-SPIRV-DAG: ConstantFalse [[bool]] [[false:[0-9]+]]
+; CHECK-SPIRV-DAG: Constant [[int]]    [[ScopeSubgroup:[0-9]+]] 3
+; CHECK-SPIRV-DAG: Constant [[char]]   [[char_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[short]]  [[short_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[int]]    [[int_0:[0-9]+]]         0
+; CHECK-SPIRV-DAG: Constant [[long]]   [[long_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[half]]   [[half_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[float]]  [[float_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[double]] [[double_0:[0-9]+]]      0
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformElect [[bool]] {{[0-9]+}} [[ScopeSubgroup]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testSubGroupElect
+; CHECK-LLVM: call spir_func i32 @_Z15sub_group_electv()
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testSubGroupElect(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z15sub_group_electv() #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z15sub_group_electv() local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformAll [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[false]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testSubGroupNonUniformAll
+; CHECK-LLVM: call spir_func i32 @_Z25sub_group_non_uniform_alli(i32 {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testSubGroupNonUniformAll(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z25sub_group_non_uniform_alli(i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z25sub_group_non_uniform_alli(i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformAny [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[false]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testSubGroupNonUniformAny
+; CHECK-LLVM: call spir_func i32 @_Z25sub_group_non_uniform_anyi(i32 {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testSubGroupNonUniformAny(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z25sub_group_non_uniform_anyi(i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z25sub_group_non_uniform_anyi(i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]]
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]]
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]]
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]]
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]]
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]]
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[float_0]]
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[half_0]]
+; CHECK-SPIRV: GroupNonUniformAllEqual [[bool]] {{[0-9]+}} [[ScopeSubgroup]] [[double_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testSubGroupNonUniformAllEqual
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equalc(i8 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equalc(i8 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equals(i16 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equals(i16 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equali(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equali(i32 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equall(i64 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equall(i64 {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equalf(float {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equalDh(half {{.*}})
+; CHECK-LLVM: call spir_func i32 @_Z31sub_group_non_uniform_all_equald(double {{.*}})
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testSubGroupNonUniformAllEqual(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equalc(i8 signext 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !7
+  %3 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equalh(i8 zeroext 0) #2
+  store i32 %3, i32 addrspace(1)* %0, align 4, !tbaa !7
+  %4 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equals(i16 signext 0) #2
+  store i32 %4, i32 addrspace(1)* %0, align 4, !tbaa !7
+  %5 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equalt(i16 zeroext 0) #2
+  store i32 %5, i32 addrspace(1)* %0, align 4, !tbaa !7
+  %6 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equali(i32 0) #2
+  store i32 %6, i32 addrspace(1)* %0, align 4, !tbaa !7
+  %7 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equalj(i32 0) #2
+  store i32 %7, i32 addrspace(1)* %0, align 4, !tbaa !7
+  %8 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equall(i64 0) #2
+  store i32 %8, i32 addrspace(1)* %0, align 4, !tbaa !7
+  %9 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equalm(i64 0) #2
+  store i32 %9, i32 addrspace(1)* %0, align 4, !tbaa !7
+  %10 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equalf(float 0.000000e+00) #2
+  store i32 %10, i32 addrspace(1)* %0, align 4, !tbaa !7
+  %11 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equalDh(half 0xH0000) #2
+  store i32 %11, i32 addrspace(1)* %0, align 4, !tbaa !7
+  %12 = tail call spir_func i32 @_Z31sub_group_non_uniform_all_equald(double 0.000000e+00) #2
+  store i32 %12, i32 addrspace(1)* %0, align 4, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equalc(i8 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equalh(i8 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equals(i16 signext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equalt(i16 zeroext) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equali(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equalj(i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equall(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equalm(i64) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equalf(float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equalDh(half) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z31sub_group_non_uniform_all_equald(double) local_unnamed_addr #1
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.1 (https://github.com/llvm/llvm-project.git cb6d58d1dcf36a29ae5dd24ff891d6552f00bac7)"}
+!3 = !{i32 1}
+!4 = !{!"none"}
+!5 = !{!"int*"}
+!6 = !{!""}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"int", !9, i64 0}
+!9 = !{!"omnipotent char", !10, i64 0}
+!10 = !{!"Simple C/C++ TBAA"}

--- a/test/transcoding/sub_group_shuffle.ll
+++ b/test/transcoding/sub_group_shuffle.ll
@@ -1,0 +1,430 @@
+;; #pragma OPENCL EXTENSION cl_khr_subgroup_shuffle : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+;; 
+;; kernel void testShuffleChar(global char* dst)
+;; {
+;; 	char v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleUChar(global uchar* dst)
+;; {
+;; 	uchar v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleShort(global short* dst)
+;; {
+;; 	short v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleUShort(global ushort* dst)
+;; {
+;; 	ushort v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleInt(global int* dst)
+;; {
+;; 	int v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleUInt(global uint* dst)
+;; {
+;; 	uint v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleLong(global long* dst)
+;; {
+;; 	long v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleULong(global ulong* dst)
+;; {
+;; 	ulong v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleFloat(global float* dst)
+;; {
+;; 	float v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleHalf(global half* dst)
+;; {
+;; 	half v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleDouble(global double* dst)
+;; {
+;; 	double v = 0;
+;;     dst[0] = sub_group_shuffle( v, 0 );
+;;     dst[1] = sub_group_shuffle_xor( v, 0 );
+;; }
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; Change DISABLED to RUN once SPIRV->LLVM translation is implemented
+; DISABLED: llvm-spirv -r %t.spv -o %t.rev.bc
+; DISABLED: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: TypeInt   [[char:[0-9]+]]   8  0
+; CHECK-SPIRV-DAG: TypeInt   [[short:[0-9]+]]  16 0
+; CHECK-SPIRV-DAG: TypeInt   [[int:[0-9]+]]    32 0
+; CHECK-SPIRV-DAG: TypeInt   [[long:[0-9]+]]   64 0
+; CHECK-SPIRV-DAG: TypeFloat [[half:[0-9]+]]   16
+; CHECK-SPIRV-DAG: TypeFloat [[float:[0-9]+]]  32
+; CHECK-SPIRV-DAG: TypeFloat [[double:[0-9]+]] 64
+
+; CHECK-SPIRV-DAG: Constant [[int]]    [[ScopeSubgroup:[0-9]+]] 3
+; CHECK-SPIRV-DAG: Constant [[char]]   [[char_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[short]]  [[short_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[int]]    [[int_0:[0-9]+]]         0
+; CHECK-SPIRV-DAG: Constant [[long]]   [[long_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[half]]   [[half_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[float]]  [[float_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[double]] [[double_0:[0-9]+]]      0
+
+; ModuleID = 'sub_group_shuffle.cl'
+source_filename = "sub_group_shuffle.cl"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleChar
+; CHECK-LLVM: call spir_func i8 @_Z17sub_group_shufflecj(i8 0, i32 0)
+; CHECK-LLVM: call spir_func i8 @_Z21sub_group_shuffle_xorcj(i8 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i8 @_Z17sub_group_shufflecj(i8 signext 0, i32 0) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func signext i8 @_Z21sub_group_shuffle_xorcj(i8 signext 0, i32 0) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z17sub_group_shufflecj(i8 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z21sub_group_shuffle_xorcj(i8 signext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleUChar
+; CHECK-LLVM: call spir_func i8 @_Z17sub_group_shufflecj(i8 0, i32 0)
+; CHECK-LLVM: call spir_func i8 @_Z21sub_group_shuffle_xorcj(i8 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleUChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !10 !kernel_arg_base_type !10 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i8 @_Z17sub_group_shufflehj(i8 zeroext 0, i32 0) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func zeroext i8 @_Z21sub_group_shuffle_xorhj(i8 zeroext 0, i32 0) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z17sub_group_shufflehj(i8 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z21sub_group_shuffle_xorhj(i8 zeroext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleShort
+; CHECK-LLVM: call spir_func i16 @_Z17sub_group_shufflesj(i16 0, i32 0)
+; CHECK-LLVM: call spir_func i16 @_Z21sub_group_shuffle_xorsj(i16 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !11 !kernel_arg_base_type !11 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i16 @_Z17sub_group_shufflesj(i16 signext 0, i32 0) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func signext i16 @_Z21sub_group_shuffle_xorsj(i16 signext 0, i32 0) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z17sub_group_shufflesj(i16 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z21sub_group_shuffle_xorsj(i16 signext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleUShort
+; CHECK-LLVM: call spir_func i16 @_Z17sub_group_shufflesj(i16 0, i32 0)
+; CHECK-LLVM: call spir_func i16 @_Z21sub_group_shuffle_xorsj(i16 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleUShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !14 !kernel_arg_base_type !14 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i16 @_Z17sub_group_shuffletj(i16 zeroext 0, i32 0) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func zeroext i16 @_Z21sub_group_shuffle_xortj(i16 zeroext 0, i32 0) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z17sub_group_shuffletj(i16 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z21sub_group_shuffle_xortj(i16 zeroext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleInt
+; CHECK-LLVM: call spir_func i32 @_Z17sub_group_shuffleij(i32 0, i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z21sub_group_shuffle_xorij(i32 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !15 !kernel_arg_base_type !15 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z17sub_group_shuffleij(i32 0, i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z21sub_group_shuffle_xorij(i32 0, i32 0) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z17sub_group_shuffleij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z21sub_group_shuffle_xorij(i32, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleUInt
+; CHECK-LLVM: call spir_func i32 @_Z17sub_group_shuffleij(i32 0, i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z21sub_group_shuffle_xorij(i32 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleUInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !18 !kernel_arg_base_type !18 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z17sub_group_shufflejj(i32 0, i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z21sub_group_shuffle_xorjj(i32 0, i32 0) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z17sub_group_shufflejj(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z21sub_group_shuffle_xorjj(i32, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleLong
+; CHECK-LLVM: call spir_func i64 @_Z17sub_group_shufflelj(i64 0, i32 0)
+; CHECK-LLVM: call spir_func i64 @_Z21sub_group_shuffle_xorlj(i64 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleLong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !19 !kernel_arg_base_type !19 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z17sub_group_shufflelj(i64 0, i32 0) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z21sub_group_shuffle_xorlj(i64 0, i32 0) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z17sub_group_shufflelj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z21sub_group_shuffle_xorlj(i64, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleULong
+; CHECK-LLVM: call spir_func i64 @_Z17sub_group_shufflelj(i64 0, i32 0)
+; CHECK-LLVM: call spir_func i64 @_Z21sub_group_shuffle_xorlj(i64 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleULong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !22 !kernel_arg_base_type !22 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z17sub_group_shufflemj(i64 0, i32 0) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z21sub_group_shuffle_xormj(i64 0, i32 0) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z17sub_group_shufflemj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z21sub_group_shuffle_xormj(i64, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[float]] {{[0-9]+}} [[ScopeSubgroup]] [[float_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[float]] {{[0-9]+}} [[ScopeSubgroup]] [[float_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleFloat
+; CHECK-LLVM: call spir_func float @_Z17sub_group_shufflefj(float 0.000000e+00, i32 0)
+; CHECK-LLVM: call spir_func float @_Z21sub_group_shuffle_xorfj(float 0.000000e+00, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleFloat(float addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !23 !kernel_arg_base_type !23 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func float @_Z17sub_group_shufflefj(float 0.000000e+00, i32 0) #2
+  store float %2, float addrspace(1)* %0, align 4, !tbaa !24
+  %3 = tail call spir_func float @_Z21sub_group_shuffle_xorfj(float 0.000000e+00, i32 0) #2
+  %4 = getelementptr inbounds float, float addrspace(1)* %0, i64 1
+  store float %3, float addrspace(1)* %4, align 4, !tbaa !24
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z17sub_group_shufflefj(float, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z21sub_group_shuffle_xorfj(float, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[half]] {{[0-9]+}} [[ScopeSubgroup]] [[half_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[half]] {{[0-9]+}} [[ScopeSubgroup]] [[half_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleHalf
+; CHECK-LLVM: call spir_func half @_Z17sub_group_shuffleDhj(half 0xH0000, i32 0)
+; CHECK-LLVM: call spir_func half @_Z21sub_group_shuffle_xorDhj(half 0xH0000, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleHalf(half addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !26 !kernel_arg_base_type !26 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func half @_Z17sub_group_shuffleDhj(half 0xH0000, i32 0) #2
+  store half %2, half addrspace(1)* %0, align 2, !tbaa !27
+  %3 = tail call spir_func half @_Z21sub_group_shuffle_xorDhj(half 0xH0000, i32 0) #2
+  %4 = getelementptr inbounds half, half addrspace(1)* %0, i64 1
+  store half %3, half addrspace(1)* %4, align 2, !tbaa !27
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z17sub_group_shuffleDhj(half, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z21sub_group_shuffle_xorDhj(half, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffle [[double]] {{[0-9]+}} [[ScopeSubgroup]] [[double_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleXor [[double]] {{[0-9]+}} [[ScopeSubgroup]] [[double_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleDouble
+; CHECK-LLVM: call spir_func double @_Z17sub_group_shuffledj(double 0.000000e+00, i32 0)
+; CHECK-LLVM: call spir_func double @_Z21sub_group_shuffle_xordj(double 0.000000e+00, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleDouble(double addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !29 !kernel_arg_base_type !29 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func double @_Z17sub_group_shuffledj(double 0.000000e+00, i32 0) #2
+  store double %2, double addrspace(1)* %0, align 8, !tbaa !30
+  %3 = tail call spir_func double @_Z21sub_group_shuffle_xordj(double 0.000000e+00, i32 0) #2
+  %4 = getelementptr inbounds double, double addrspace(1)* %0, i64 1
+  store double %3, double addrspace(1)* %4, align 8, !tbaa !30
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z17sub_group_shuffledj(double, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z21sub_group_shuffle_xordj(double, i32) local_unnamed_addr #1
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.1 (https://github.com/llvm/llvm-project.git cb6d58d1dcf36a29ae5dd24ff891d6552f00bac7)"}
+!3 = !{i32 1}
+!4 = !{!"none"}
+!5 = !{!"char*"}
+!6 = !{!""}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !{!"uchar*"}
+!11 = !{!"short*"}
+!12 = !{!13, !13, i64 0}
+!13 = !{!"short", !8, i64 0}
+!14 = !{!"ushort*"}
+!15 = !{!"int*"}
+!16 = !{!17, !17, i64 0}
+!17 = !{!"int", !8, i64 0}
+!18 = !{!"uint*"}
+!19 = !{!"long*"}
+!20 = !{!21, !21, i64 0}
+!21 = !{!"long", !8, i64 0}
+!22 = !{!"ulong*"}
+!23 = !{!"float*"}
+!24 = !{!25, !25, i64 0}
+!25 = !{!"float", !8, i64 0}
+!26 = !{!"half*"}
+!27 = !{!28, !28, i64 0}
+!28 = !{!"half", !8, i64 0}
+!29 = !{!"double*"}
+!30 = !{!31, !31, i64 0}
+!31 = !{!"double", !8, i64 0}
+
+

--- a/test/transcoding/sub_group_shuffle_relative.ll
+++ b/test/transcoding/sub_group_shuffle_relative.ll
@@ -1,0 +1,428 @@
+;; #pragma OPENCL EXTENSION cl_khr_subgroup_shuffle_relative : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+;; 
+;; kernel void testShuffleRelativeChar(global char* dst)
+;; {
+;; 	char v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleRelativeUChar(global uchar* dst)
+;; {
+;; 	uchar v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleRelativeShort(global short* dst)
+;; {
+;; 	short v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleRelativeUShort(global ushort* dst)
+;; {
+;; 	ushort v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleRelativeInt(global int* dst)
+;; {
+;; 	int v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleRelativeUInt(global uint* dst)
+;; {
+;; 	uint v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleRelativeLong(global long* dst)
+;; {
+;; 	long v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleRelativeULong(global ulong* dst)
+;; {
+;; 	ulong v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleRelativeFloat(global float* dst)
+;; {
+;; 	float v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleRelativeHalf(global half* dst)
+;; {
+;; 	half v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+;; 
+;; kernel void testShuffleRelativeDouble(global double* dst)
+;; {
+;; 	double v = 0;
+;;     dst[0] = sub_group_shuffle_up( v, 0 );
+;;     dst[1] = sub_group_shuffle_down( v, 0 );
+;; }
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; Change DISABLED to RUN once SPIRV->LLVM translation is implemented
+; DISABLED: llvm-spirv -r %t.spv -o %t.rev.bc
+; DISABLED: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: TypeInt   [[char:[0-9]+]]   8  0
+; CHECK-SPIRV-DAG: TypeInt   [[short:[0-9]+]]  16 0
+; CHECK-SPIRV-DAG: TypeInt   [[int:[0-9]+]]    32 0
+; CHECK-SPIRV-DAG: TypeInt   [[long:[0-9]+]]   64 0
+; CHECK-SPIRV-DAG: TypeFloat [[half:[0-9]+]]   16
+; CHECK-SPIRV-DAG: TypeFloat [[float:[0-9]+]]  32
+; CHECK-SPIRV-DAG: TypeFloat [[double:[0-9]+]] 64
+
+; CHECK-SPIRV-DAG: Constant [[int]]    [[ScopeSubgroup:[0-9]+]] 3
+; CHECK-SPIRV-DAG: Constant [[char]]   [[char_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[short]]  [[short_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[int]]    [[int_0:[0-9]+]]         0
+; CHECK-SPIRV-DAG: Constant [[long]]   [[long_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[half]]   [[half_0:[0-9]+]]        0
+; CHECK-SPIRV-DAG: Constant [[float]]  [[float_0:[0-9]+]]       0
+; CHECK-SPIRV-DAG: Constant [[double]] [[double_0:[0-9]+]]      0
+
+; ModuleID = 'sub_group_shuffle_relative.cl'
+source_filename = "sub_group_shuffle_relative.cl"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeChar
+; CHECK-LLVM: call spir_func i8 @_Z20sub_group_shuffle_upcj(i8 0, i32 0)
+; CHECK-LLVM: call spir_func i8 @_Z22sub_group_shuffle_downcj(i8 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i8 @_Z20sub_group_shuffle_upcj(i8 signext 0, i32 0) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func signext i8 @_Z22sub_group_shuffle_downcj(i8 signext 0, i32 0) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z20sub_group_shuffle_upcj(i8 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i8 @_Z22sub_group_shuffle_downcj(i8 signext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[char]] {{[0-9]+}} [[ScopeSubgroup]] [[char_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeUChar
+; CHECK-LLVM: call spir_func i8 @_Z20sub_group_shuffle_upcj(i8 0, i32 0)
+; CHECK-LLVM: call spir_func i8 @_Z22sub_group_shuffle_downcj(i8 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeUChar(i8 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !10 !kernel_arg_base_type !10 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i8 @_Z20sub_group_shuffle_uphj(i8 zeroext 0, i32 0) #2
+  store i8 %2, i8 addrspace(1)* %0, align 1, !tbaa !7
+  %3 = tail call spir_func zeroext i8 @_Z22sub_group_shuffle_downhj(i8 zeroext 0, i32 0) #2
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1
+  store i8 %3, i8 addrspace(1)* %4, align 1, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z20sub_group_shuffle_uphj(i8 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i8 @_Z22sub_group_shuffle_downhj(i8 zeroext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeShort
+; CHECK-LLVM: call spir_func i16 @_Z20sub_group_shuffle_upsj(i16 0, i32 0)
+; CHECK-LLVM: call spir_func i16 @_Z22sub_group_shuffle_downsj(i16 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !11 !kernel_arg_base_type !11 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func signext i16 @_Z20sub_group_shuffle_upsj(i16 signext 0, i32 0) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func signext i16 @_Z22sub_group_shuffle_downsj(i16 signext 0, i32 0) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z20sub_group_shuffle_upsj(i16 signext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func signext i16 @_Z22sub_group_shuffle_downsj(i16 signext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[short]] {{[0-9]+}} [[ScopeSubgroup]] [[short_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeUShort
+; CHECK-LLVM: call spir_func i16 @_Z20sub_group_shuffle_upsj(i16 0, i32 0)
+; CHECK-LLVM: call spir_func i16 @_Z22sub_group_shuffle_downsj(i16 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeUShort(i16 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !14 !kernel_arg_base_type !14 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func zeroext i16 @_Z20sub_group_shuffle_uptj(i16 zeroext 0, i32 0) #2
+  store i16 %2, i16 addrspace(1)* %0, align 2, !tbaa !12
+  %3 = tail call spir_func zeroext i16 @_Z22sub_group_shuffle_downtj(i16 zeroext 0, i32 0) #2
+  %4 = getelementptr inbounds i16, i16 addrspace(1)* %0, i64 1
+  store i16 %3, i16 addrspace(1)* %4, align 2, !tbaa !12
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z20sub_group_shuffle_uptj(i16 zeroext, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func zeroext i16 @_Z22sub_group_shuffle_downtj(i16 zeroext, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeInt
+; CHECK-LLVM: call spir_func i32 @_Z20sub_group_shuffle_upij(i32 0, i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z22sub_group_shuffle_downij(i32 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !15 !kernel_arg_base_type !15 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z20sub_group_shuffle_upij(i32 0, i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z22sub_group_shuffle_downij(i32 0, i32 0) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z20sub_group_shuffle_upij(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z22sub_group_shuffle_downij(i32, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[int]] {{[0-9]+}} [[ScopeSubgroup]] [[int_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeUInt
+; CHECK-LLVM: call spir_func i32 @_Z20sub_group_shuffle_upij(i32 0, i32 0)
+; CHECK-LLVM: call spir_func i32 @_Z22sub_group_shuffle_downij(i32 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeUInt(i32 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !18 !kernel_arg_base_type !18 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i32 @_Z20sub_group_shuffle_upjj(i32 0, i32 0) #2
+  store i32 %2, i32 addrspace(1)* %0, align 4, !tbaa !16
+  %3 = tail call spir_func i32 @_Z22sub_group_shuffle_downjj(i32 0, i32 0) #2
+  %4 = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 1
+  store i32 %3, i32 addrspace(1)* %4, align 4, !tbaa !16
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z20sub_group_shuffle_upjj(i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i32 @_Z22sub_group_shuffle_downjj(i32, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeLong
+; CHECK-LLVM: call spir_func i64 @_Z20sub_group_shuffle_uplj(i64 0, i32 0)
+; CHECK-LLVM: call spir_func i64 @_Z22sub_group_shuffle_downlj(i64 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeLong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !19 !kernel_arg_base_type !19 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z20sub_group_shuffle_uplj(i64 0, i32 0) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z22sub_group_shuffle_downlj(i64 0, i32 0) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z20sub_group_shuffle_uplj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z22sub_group_shuffle_downlj(i64, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[long]] {{[0-9]+}} [[ScopeSubgroup]] [[long_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeULong
+; CHECK-LLVM: call spir_func i64 @_Z20sub_group_shuffle_uplj(i64 0, i32 0)
+; CHECK-LLVM: call spir_func i64 @_Z22sub_group_shuffle_downlj(i64 0, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeULong(i64 addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !22 !kernel_arg_base_type !22 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func i64 @_Z20sub_group_shuffle_upmj(i64 0, i32 0) #2
+  store i64 %2, i64 addrspace(1)* %0, align 8, !tbaa !20
+  %3 = tail call spir_func i64 @_Z22sub_group_shuffle_downmj(i64 0, i32 0) #2
+  %4 = getelementptr inbounds i64, i64 addrspace(1)* %0, i64 1
+  store i64 %3, i64 addrspace(1)* %4, align 8, !tbaa !20
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z20sub_group_shuffle_upmj(i64, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func i64 @_Z22sub_group_shuffle_downmj(i64, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[float]] {{[0-9]+}} [[ScopeSubgroup]] [[float_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[float]] {{[0-9]+}} [[ScopeSubgroup]] [[float_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeFloat
+; CHECK-LLVM: call spir_func float @_Z20sub_group_shuffle_upfj(float 0.000000e+00, i32 0)
+; CHECK-LLVM: call spir_func float @_Z22sub_group_shuffle_downfj(float 0.000000e+00, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeFloat(float addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !23 !kernel_arg_base_type !23 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func float @_Z20sub_group_shuffle_upfj(float 0.000000e+00, i32 0) #2
+  store float %2, float addrspace(1)* %0, align 4, !tbaa !24
+  %3 = tail call spir_func float @_Z22sub_group_shuffle_downfj(float 0.000000e+00, i32 0) #2
+  %4 = getelementptr inbounds float, float addrspace(1)* %0, i64 1
+  store float %3, float addrspace(1)* %4, align 4, !tbaa !24
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z20sub_group_shuffle_upfj(float, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func float @_Z22sub_group_shuffle_downfj(float, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[half]] {{[0-9]+}} [[ScopeSubgroup]] [[half_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[half]] {{[0-9]+}} [[ScopeSubgroup]] [[half_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeHalf
+; CHECK-LLVM: call spir_func half @_Z20sub_group_shuffle_upDhj(half 0xH0000, i32 0)
+; CHECK-LLVM: call spir_func half @_Z22sub_group_shuffle_downDhj(half 0xH0000, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeHalf(half addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !26 !kernel_arg_base_type !26 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func half @_Z20sub_group_shuffle_upDhj(half 0xH0000, i32 0) #2
+  store half %2, half addrspace(1)* %0, align 2, !tbaa !27
+  %3 = tail call spir_func half @_Z22sub_group_shuffle_downDhj(half 0xH0000, i32 0) #2
+  %4 = getelementptr inbounds half, half addrspace(1)* %0, i64 1
+  store half %3, half addrspace(1)* %4, align 2, !tbaa !27
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z20sub_group_shuffle_upDhj(half, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func half @_Z22sub_group_shuffle_downDhj(half, i32) local_unnamed_addr #1
+
+; CHECK-SPIRV-LABEL: 5 Function
+; CHECK-SPIRV: GroupNonUniformShuffleUp [[double]] {{[0-9]+}} [[ScopeSubgroup]] [[double_0]] [[int_0]]
+; CHECK-SPIRV: GroupNonUniformShuffleDown [[double]] {{[0-9]+}} [[ScopeSubgroup]] [[double_0]] [[int_0]]
+; CHECK-SPIRV: FunctionEnd
+
+; CHECK-LLVM-LABEL: @testShuffleRelativeDouble
+; CHECK-LLVM: call spir_func double @_Z20sub_group_shuffle_updj(double 0.000000e+00, i32 0)
+; CHECK-LLVM: call spir_func double @_Z22sub_group_shuffle_downdj(double 0.000000e+00, i32 0)
+
+; Function Attrs: convergent nounwind
+define dso_local spir_kernel void @testShuffleRelativeDouble(double addrspace(1)* nocapture) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !29 !kernel_arg_base_type !29 !kernel_arg_type_qual !6 {
+  %2 = tail call spir_func double @_Z20sub_group_shuffle_updj(double 0.000000e+00, i32 0) #2
+  store double %2, double addrspace(1)* %0, align 8, !tbaa !30
+  %3 = tail call spir_func double @_Z22sub_group_shuffle_downdj(double 0.000000e+00, i32 0) #2
+  %4 = getelementptr inbounds double, double addrspace(1)* %0, i64 1
+  store double %3, double addrspace(1)* %4, align 8, !tbaa !30
+  ret void
+}
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z20sub_group_shuffle_updj(double, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare dso_local spir_func double @_Z22sub_group_shuffle_downdj(double, i32) local_unnamed_addr #1
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.1 (https://github.com/llvm/llvm-project.git cb6d58d1dcf36a29ae5dd24ff891d6552f00bac7)"}
+!3 = !{i32 1}
+!4 = !{!"none"}
+!5 = !{!"char*"}
+!6 = !{!""}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C/C++ TBAA"}
+!10 = !{!"uchar*"}
+!11 = !{!"short*"}
+!12 = !{!13, !13, i64 0}
+!13 = !{!"short", !8, i64 0}
+!14 = !{!"ushort*"}
+!15 = !{!"int*"}
+!16 = !{!17, !17, i64 0}
+!17 = !{!"int", !8, i64 0}
+!18 = !{!"uint*"}
+!19 = !{!"long*"}
+!20 = !{!21, !21, i64 0}
+!21 = !{!"long", !8, i64 0}
+!22 = !{!"ulong*"}
+!23 = !{!"float*"}
+!24 = !{!25, !25, i64 0}
+!25 = !{!"float", !8, i64 0}
+!26 = !{!"half*"}
+!27 = !{!28, !28, i64 0}
+!28 = !{!"half", !8, i64 0}
+!29 = !{!"double*"}
+!30 = !{!31, !31, i64 0}
+!31 = !{!"double", !8, i64 0}


### PR DESCRIPTION
Testing SPIRV->LLVM translation is disabled in this commit. Enable this
once it gets implemented.