### PR TITLE
extend spirv-max-version option to versions 1.2 and 1.3

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -970,8 +970,7 @@ void OCL20ToSPIRV::visitCallGroupBuiltin(CallInst *CI,
                                   .Case("ballot_exclusive_scan", "add")
                                   .Default(FuncName.take_back(
                                       3)); // assumes op is three characters
-          if (GroupOp.startswith("_"))
-            GroupOp = GroupOp.take_back(2); // when op is two characters
+          GroupOp.consume_front("_");      // when op is two characters
           assert(!GroupOp.empty() && "Invalid OpenCL group builtin function");
           char OpTyC = 0;
           auto OpTy = F->getReturnType();

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -102,7 +102,9 @@ static cl::opt<VersionNumber> MaxSPIRVVersion(
     "spirv-max-version",
     cl::desc("Choose maximum SPIR-V version which can be emitted"),
     cl::values(clEnumValN(VersionNumber::SPIRV_1_0, "1.0", "SPIR-V 1.0"),
-               clEnumValN(VersionNumber::SPIRV_1_1, "1.1", "SPIR-V 1.1")),
+               clEnumValN(VersionNumber::SPIRV_1_1, "1.1", "SPIR-V 1.1"),
+               clEnumValN(VersionNumber::SPIRV_1_2, "1.2", "SPIR-V 1.2"),
+               clEnumValN(VersionNumber::SPIRV_1_3, "1.3", "SPIR-V 1.3")),
     cl::init(VersionNumber::MaximumVersion));
 
 static cl::list<std::string>


### PR DESCRIPTION
This fix applies reviewers suggestions from: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/505